### PR TITLE
Basic creation of analytic unit fails #79

### DIFF
--- a/analytics/detectors/general_detector.py
+++ b/analytics/detectors/general_detector.py
@@ -92,7 +92,7 @@ class GeneralDetector:
 
         start_index = self.data_prov.get_upper_bound(last_prediction_time)
         stop_index = self.data_prov.size()
-        last_prediction_time = last_prediction_time.value / NANOSECONDS_IN_MS
+        last_prediction_time = int(last_prediction_time.value / NANOSECONDS_IN_MS)
 
         predicted_anomalies = []
         if start_index < stop_index:

--- a/analytics/detectors/general_detector.py
+++ b/analytics/detectors/general_detector.py
@@ -7,6 +7,7 @@ import config
 import os.path
 import json
 
+NANOSECONDS_IN_MS = 1000000
 
 logger = logging.getLogger('analytic_toolset')
 
@@ -91,8 +92,7 @@ class GeneralDetector:
 
         start_index = self.data_prov.get_upper_bound(last_prediction_time)
         stop_index = self.data_prov.size()
-
-        last_prediction_time = int(last_prediction_time.timestamp() * 1000)
+        last_prediction_time = last_prediction_time.value / NANOSECONDS_IN_MS
 
         predicted_anomalies = []
         if start_index < stop_index:


### PR DESCRIPTION
Fixes https://github.com/hastic/hastic-server/issues/79

There is an error `OSError: [Errno 22] Invalid argument` when you're trying to get `timestamp()` of `pd.DateTime` which is near Unix epoch start (1970-01-01)
But there is also `.value` attribute, which does almost the same but with nanoseconds precision and doesn't fail