### PR TITLE
Fix GET /analyticUnits/status

### DIFF
--- a/server/src/routes/analytic_units_router.ts
+++ b/server/src/routes/analytic_units_router.ts
@@ -12,7 +12,7 @@ async function getStatus(ctx: Router.IRouterContext) {
       throw new Error('Cannot get status of undefined id');
     }
 
-    let analyticUnit: AnalyticUnit.AnalyticUnit = await AnalyticUnit.findById(analyticUnitId);
+    let analyticUnit = await AnalyticUnit.findById(analyticUnitId);
 
     ctx.response.body = {
       status: analyticUnit.status
@@ -36,7 +36,7 @@ async function getUnit(ctx: Router.IRouterContext) {
       throw new Error('No id param in query');
     }
 
-    let analyticUnit: AnalyticUnit.AnalyticUnit = await AnalyticUnit.findById(analyticUnitId);
+    let analyticUnit = await AnalyticUnit.findById(analyticUnitId);
 
     ctx.response.body = {
       name: analyticUnit.name,

--- a/server/src/routes/analytic_units_router.ts
+++ b/server/src/routes/analytic_units_router.ts
@@ -14,18 +14,17 @@ async function getStatus(ctx: Router.IRouterContext) {
     }
 
     let unit: AnalyticUnit.AnalyticUnit = await AnalyticUnit.findById(id);
-    let errorMsg
-    if(unit.status === 'FAILED') {
-      errorMsg = unit.error;
-    } else {
-      errorMsg = '';
-    }
-    ctx.response.body = { 
+    let errorMessage = unit.error || '';
+
+    ctx.response.body = {
       status: unit.status,
-      errorMessage: errorMsg };
+      errorMessage
+    };
 
   } catch(e) {
-    console.error(e)
+    console.error(e);
+    ctx.response.status = 404;
+    ctx.response.body = 'Can`t find anything';
   }
 }
 
@@ -64,7 +63,7 @@ async function createUnit(ctx: Router.IRouterContext) {
       message: `Creation error: ${e.message}`
     };
   }
-  
+
 }
 
 async function deleteUnit(ctx: Router.IRouterContext) {

--- a/server/src/routes/analytic_units_router.ts
+++ b/server/src/routes/analytic_units_router.ts
@@ -7,12 +7,25 @@ import * as Router from 'koa-router';
 
 async function getStatus(ctx: Router.IRouterContext) {
   try {
-    ctx.response.body = { status: 'READY', errorMessage: undefined };
+    let id = ctx.request.query.id;
+
+    if(id === undefined) {
+      throw new Error('Cannot get status of undefined id')
+    }
+
+    let unit: AnalyticUnit.AnalyticUnit = await AnalyticUnit.findById(id);
+    let errorMsg
+    if(unit.status === 'FAILED') {
+      errorMsg = unit.error;
+    } else {
+      errorMsg = '';
+    }
+    ctx.response.body = { 
+      status: unit.status,
+      errorMessage: errorMsg };
+
   } catch(e) {
-    console.error(e);
-    // TODO: better send 404 when we know than isn`t found
-    ctx.response.status = 500;
-    ctx.response.body = { error: 'Can`t return anything' };
+    console.error(e)
   }
 }
 

--- a/server/src/routes/analytic_units_router.ts
+++ b/server/src/routes/analytic_units_router.ts
@@ -7,20 +7,20 @@ import * as Router from 'koa-router';
 
 async function getStatus(ctx: Router.IRouterContext) {
   try {
-    let id = ctx.request.query.id;
-
-    if(id === undefined) {
+    let analyticUnitId = ctx.request.query.id;
+    if(analyticUnitId === undefined) {
       throw new Error('Cannot get status of undefined id');
     }
 
-    let unit: AnalyticUnit.AnalyticUnit = await AnalyticUnit.findById(id);
-    let errorMessage = unit.error || '';
+    let analyticUnit: AnalyticUnit.AnalyticUnit = await AnalyticUnit.findById(analyticUnitId);
 
     ctx.response.body = {
-      status: unit.status,
-      errorMessage
+      status: analyticUnit.status
     };
 
+    if(analyticUnit.status === AnalyticUnit.AnalyticUnitStatus.FAILED) {
+      ctx.response.body.errorMessage = analyticUnit.error;
+    }
   } catch(e) {
     console.error(e);
     ctx.response.status = 404;
@@ -30,18 +30,18 @@ async function getStatus(ctx: Router.IRouterContext) {
 
 async function getUnit(ctx: Router.IRouterContext) {
   try {
-    let id = ctx.request.query.id;
+    let analyticUnitId = ctx.request.query.id;
 
-    if(id === undefined) {
+    if(analyticUnitId === undefined) {
       throw new Error('No id param in query');
     }
 
-    let unit: AnalyticUnit.AnalyticUnit = await AnalyticUnit.findById(id);
+    let analyticUnit: AnalyticUnit.AnalyticUnit = await AnalyticUnit.findById(analyticUnitId);
 
     ctx.response.body = {
-      name: unit.name,
-      metric: unit.metric,
-      status: unit.status
+      name: analyticUnit.name,
+      metric: analyticUnit.metric,
+      status: analyticUnit.status
     };
 
   } catch(e) {

--- a/server/src/routes/analytic_units_router.ts
+++ b/server/src/routes/analytic_units_router.ts
@@ -1,6 +1,6 @@
 import * as AnalyticUnit from '../models/analytic_unit_model';
 
-import { createAnalyticUnitFromObject } from '../controllers/analytics_controller'
+import { createAnalyticUnitFromObject } from '../controllers/analytics_controller';
 
 import * as Router from 'koa-router';
 
@@ -10,7 +10,7 @@ async function getStatus(ctx: Router.IRouterContext) {
     let id = ctx.request.query.id;
 
     if(id === undefined) {
-      throw new Error('Cannot get status of undefined id')
+      throw new Error('Cannot get status of undefined id');
     }
 
     let unit: AnalyticUnit.AnalyticUnit = await AnalyticUnit.findById(id);


### PR DESCRIPTION
`GET /analyticUnits/status` always returned 'READY' status.
Make it return actual analytic unit status.