### PR TITLE
Convert cache fields in reverse peak model to float

### DIFF
--- a/analytics/models/reverse_peak_model.py
+++ b/analytics/models/reverse_peak_model.py
@@ -52,12 +52,12 @@ class ReversePeakModel(Model):
                 convolve_list.append(max(convolve))
 
         if len(confidences) > 0:
-            self.state['confidence'] = min(confidences)
+            self.state['confidence'] = float(min(confidences))
         else:
             self.state['confidence'] = 1.5
 
         if len(convolve_list) > 0:
-            self.state['convolve_max'] = max(convolve_list)
+            self.state['convolve_max'] = float(max(convolve_list))
         else:
             self.state['convolve_max'] = 570000
         


### PR DESCRIPTION
Fixes https://github.com/hastic/hastic-server/issues/125
Couldn't reproduce after fixing https://github.com/hastic/hastic-server/issues/126
But cache fields anyway should've been converted to float