### PR TITLE
Datarange sent to models #137

### DIFF
--- a/server/src/controllers/analytics_controller.ts
+++ b/server/src/controllers/analytics_controller.ts
@@ -82,7 +82,7 @@ function getQueryRangeForLearningBySegments(segments: Segment.Segment[]) {
   let to = _.maxBy(segments, s => s.to).to;
   let diff = to - from;
   from -= Math.round(diff);
-  to += Math.round(diff);
+  to = Date.now();
 
   return { from, to };
 }


### PR DESCRIPTION
closes https://github.com/hastic/hastic-server/issues/137

Datarange sent to models now uses the range from last segment - diff, to current date.

