### PR TITLE
Add a note to README.md that the port should be opened in firewall #145

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ docker run -d \
   hastic/server
 ```
 
-**Make sure that HASTIC_PORT is opened on your system. Default value is ```8000```.**
+**Make sure that HASTIC_PORT is opened in your firewall. Default value is 8000.**
 
 ### Changelog
 

--- a/README.md
+++ b/README.md
@@ -113,6 +113,8 @@ docker run -d \
   hastic/server
 ```
 
+**Make sure that HASTIC_PORT is opened on your system. Default value is ```8000```.**
+
 ### Changelog
 
 ### [0.2.2-alpha] - 2018-09-12


### PR DESCRIPTION
closes https://github.com/hastic/hastic-server/issues/145

![image](https://user-images.githubusercontent.com/22073083/45432782-5bc77680-b6b3-11e8-95ac-d62caf42a5de.png)
