### PR TITLE
Can't see analytics' stderr in docker logs #399

### DIFF
--- a/analytics/Dockerfile
+++ b/analytics/Dockerfile
@@ -17,4 +17,4 @@ VOLUME [ "/var/www/data" ]
 
 COPY . /var/www/analytics/
 
-CMD ["python", "bin/server"]
+CMD ["python", "-u", "bin/server"]


### PR DESCRIPTION
Fixes #399 

- Enable unbuffered output