### PR TITLE
Accept various URL inputs #416

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -50,9 +50,9 @@
     "ts-jest": "^23.1.1",
     "ts-loader": "^4.4.1",
     "typescript": "^2.8.3",
+    "url-parse": "^1.4.4",
     "webpack": "^4.12.0",
     "webpack-cli": "^3.0.8",
-    "zeromq": "^4.6.0",
-    "url-parse": "^1.4.4"
+    "zeromq": "^4.6.0"
   }
 }

--- a/server/package.json
+++ b/server/package.json
@@ -19,7 +19,9 @@
     "url": "https://github.com/hastic/hastic-server/issues"
   },
   "homepage": "https://github.com/hastic/hastic-server#readme",
-  "dependencies": {},
+  "dependencies": {
+    "url-parse": "^1.4.4"
+  },
   "devDependencies": {
     "@types/jest": "^23.1.1",
     "@types/koa": "^2.0.46",

--- a/server/package.json
+++ b/server/package.json
@@ -19,9 +19,7 @@
     "url": "https://github.com/hastic/hastic-server/issues"
   },
   "homepage": "https://github.com/hastic/hastic-server#readme",
-  "dependencies": {
-    "url-parse": "^1.4.4"
-  },
+  "dependencies": {},
   "devDependencies": {
     "@types/jest": "^23.1.1",
     "@types/koa": "^2.0.46",
@@ -54,6 +52,7 @@
     "typescript": "^2.8.3",
     "webpack": "^4.12.0",
     "webpack-cli": "^3.0.8",
-    "zeromq": "^4.6.0"
+    "zeromq": "^4.6.0",
+    "url-parse": "^1.4.4"
   }
 }

--- a/server/spec/utils/url.jest.ts
+++ b/server/spec/utils/url.jest.ts
@@ -1,0 +1,24 @@
+import { normalizeUrl } from '../../src/utils/url';
+
+describe('Normalize URL', function() {
+  const cases = [
+    { value: 'localhost:8000', expected: 'http://localhost:8000' },
+    { value: 'localhost:8000/', expected: 'http://localhost:8000' },
+    { value: 'http://localhost:3000', expected: 'http://localhost:3000' },
+    { value: 'http://localhost:3000/', expected: 'http://localhost:3000' },
+    { value: 'https://localhost:8000', expected: 'https://localhost:8000' },
+    { value: 'https://localhost:8000/', expected: 'https://localhost:8000' },
+    { value: 'http://example.com', expected: 'http://example.com' },
+    { value: 'http://example.com/', expected: 'http://example.com' },
+    { value: 'https://example.com', expected: 'https://example.com' },
+    { value: 'https://example.com/', expected: 'https://example.com' },
+    { value: 'https://example.com/grafana', expected: 'https://example.com/grafana' },
+    { value: 'https://example.com/grafana/', expected: 'https://example.com/grafana' },
+  ];
+
+  it('should normalize URLs correctly', function() {
+    cases.forEach(testCase => {
+      expect(normalizeUrl(testCase.value)).toBe(testCase.expected);
+    });
+  });
+});

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -60,7 +60,7 @@ function getConfigField(field: string, defaultVal?: any) {
   return val;
 }
 
-function checkUrl(grafanaUrl) {
+function checkUrl(grafanaUrl: string) {
   let urlObj = new url(grafanaUrl);
   if(urlObj.protocol !== 'http:' && urlObj.protocol !== 'https:') {
     grafanaUrl = 'http:' + grafanaUrl;
@@ -68,13 +68,14 @@ function checkUrl(grafanaUrl) {
     console.log('No protocol provided in GRAFANA_URL -> inserting "http:"');
   }
   if(urlObj.slashes === false) {
-    urlObj = new url(urlObj.protocol + '//' + urlObj.pathname);
+    urlObj = new url(`${urlObj.protocol}//${urlObj.pathname}`);
     console.log('No slashes were provided after the protocol -> inserting slashes');
   } 
   if(urlObj.pathname.slice(-1) === '/') {
     urlObj.pathname = urlObj.pathname.slice(0, -1);
+    console.log('Removing the slash at the end of GRAFANA_URL');
   }
-  let finalUrl = urlObj.protocol + '//' + urlObj.hostname;
+  let finalUrl = `${urlObj.protocol}//${urlObj.hostname}`;
   if(urlObj.port !== '') {
     finalUrl = finalUrl + ':' + urlObj.port;
   }

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -63,7 +63,8 @@ function getConfigField(field: string, defaultVal?: any) {
 function checkUrl(grafanaUrl) {
   let urlObj = new url(grafanaUrl);
   if(urlObj.protocol !== 'http:' && urlObj.protocol !== 'https:') {
-    urlObj.protocol = 'http';
+    grafanaUrl = 'http:' + grafanaUrl;
+    urlObj = new url(grafanaUrl);
     console.log('No protocol provided in GRAFANA_URL -> inserting "http:"');
   }
   if(urlObj.slashes === false) {
@@ -72,17 +73,14 @@ function checkUrl(grafanaUrl) {
   } 
   if(urlObj.pathname.slice(-1) === '/') {
     urlObj.pathname = urlObj.pathname.slice(0, -1);
-    console.log('Removing the slash at the end of the GRAFANA_URL')
   }
   let finalUrl = urlObj.protocol + '//' + urlObj.hostname;
-  console.log(urlObj)
   if(urlObj.port !== '') {
     finalUrl = finalUrl + ':' + urlObj.port;
   }
   if(urlObj.pathname !== '') {
     finalUrl = finalUrl + urlObj.pathname;
   }
-  console.log(finalUrl);
   return finalUrl;
 }
 

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -62,20 +62,27 @@ function getConfigField(field: string, defaultVal?: any) {
 
 function checkUrl(grafanaUrl) {
   let urlObj = new url(grafanaUrl);
-  console.log(urlObj);
-  if (urlObj.protocol != 'http:' && urlObj.protocol != 'https:') {
+  if(urlObj.protocol !== 'http:' && urlObj.protocol !== 'https:') {
     urlObj.protocol = 'http';
-    console.log(urlObj);
-  } else if (urlObj.slashes === false) {
-    throw 'Provide proper slashes after the protocol like this "http://" in GRAFANA_URL field in config.json and restart'
-  } else if (isNaN(urlObj.port) && (urlObj.port !== '')) {
-    throw 'Provide valid port number in GRAFANA_URL field in config.json and restart'
-  } else if (urlObj.pathname !== '') {
-    if (urlObj.pathname.slice(-1) === '/') {
-      throw 'Please remove the "/" (slash) at the end of GRAFANA_URL field in config.json and restart'
-    }
+    console.log('No protocol provided in GRAFANA_URL -> inserting "http:"');
+  }
+  if(urlObj.slashes === false) {
+    urlObj = new url(urlObj.protocol + '//' + urlObj.pathname);
+    console.log('No slashes were provided after the protocol -> inserting slashes');
+  } 
+  if(urlObj.pathname.slice(-1) === '/') {
+    urlObj.pathname = urlObj.pathname.slice(0, -1);
+    console.log('Removing the slash at the end of the GRAFANA_URL')
   }
   let finalUrl = urlObj.protocol + '//' + urlObj.hostname;
+  console.log(urlObj)
+  if(urlObj.port !== '') {
+    finalUrl = finalUrl + ':' + urlObj.port;
+  }
+  if(urlObj.pathname !== '') {
+    finalUrl = finalUrl + urlObj.pathname;
+  }
+  console.log(finalUrl);
   return finalUrl;
 }
 

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -1,9 +1,9 @@
+import { getJsonDataSync } from './services/json_service';
+import { normalizeUrl } from './utils/url';
+
 import * as path from 'path';
 import * as fs from 'fs';
 import * as os from 'os';
-import * as url from 'url-parse';
-
-import { getJsonDataSync } from './services/json_service';
 
 
 let configFile = path.join(__dirname, '../../config.json');
@@ -25,7 +25,7 @@ export const ZMQ_IPC_PATH = getConfigField('ZMQ_IPC_PATH', path.join(os.tmpdir()
 export const ZMQ_DEV_PORT = getConfigField('ZMQ_DEV_PORT', '8002');
 export const ZMQ_HOST = getConfigField('ZMQ_HOST', '127.0.0.1');
 export const HASTIC_API_KEY = getConfigField('HASTIC_API_KEY');
-export const GRAFANA_URL = checkUrl(getConfigField('GRAFANA_URL', null));
+export const GRAFANA_URL = normalizeUrl(getConfigField('GRAFANA_URL', null));
 export const HASTIC_WEBHOOK_URL = getConfigField('HASTIC_WEBHOOK_URL', null);
 export const HASTIC_WEBHOOK_TYPE = getConfigField('HASTIC_WEBHOOK_TYPE', 'application/x-www-form-urlencoded');
 export const HASTIC_WEBHOOK_SECRET = getConfigField('HASTIC_WEBHOOK_SECRET', null);
@@ -58,31 +58,6 @@ function getConfigField(field: string, defaultVal?: any) {
     return defaultVal;
   }
   return val;
-}
-
-function checkUrl(grafanaUrl: string) {
-  let urlObj = new url(grafanaUrl);
-  if(urlObj.protocol !== 'http:' && urlObj.protocol !== 'https:') {
-    grafanaUrl = 'http:' + grafanaUrl;
-    urlObj = new url(grafanaUrl);
-    console.log('No protocol provided in GRAFANA_URL -> inserting "http:"');
-  }
-  if(urlObj.slashes === false) {
-    urlObj = new url(`${urlObj.protocol}//${urlObj.pathname}`);
-    console.log('No slashes were provided after the protocol -> inserting slashes');
-  } 
-  if(urlObj.pathname.slice(-1) === '/') {
-    urlObj.pathname = urlObj.pathname.slice(0, -1);
-    console.log('Removing the slash at the end of GRAFANA_URL');
-  }
-  let finalUrl = `${urlObj.protocol}//${urlObj.hostname}`;
-  if(urlObj.port !== '') {
-    finalUrl = finalUrl + ':' + urlObj.port;
-  }
-  if(urlObj.pathname !== '') {
-    finalUrl = finalUrl + urlObj.pathname;
-  }
-  return finalUrl;
 }
 
 function getPackageVersion() {

--- a/server/src/utils/url.ts
+++ b/server/src/utils/url.ts
@@ -1,0 +1,26 @@
+import * as url from 'url-parse';
+
+export function normalizeUrl(grafanaUrl: string) {
+  let urlObj = new url(grafanaUrl);
+  if(urlObj.protocol !== 'http:' && urlObj.protocol !== 'https:') {
+    grafanaUrl = `http://${grafanaUrl}`;
+    urlObj = new url(grafanaUrl);
+    console.log('No protocol provided in GRAFANA_URL -> inserting "http://"');
+  }
+  if(urlObj.slashes === false) {
+    urlObj = new url(`${urlObj.protocol}//${urlObj.pathname}`);
+    console.log('No slashes were provided after the protocol -> inserting slashes');
+  } 
+  if(urlObj.pathname.slice(-1) === '/') {
+    urlObj.pathname = urlObj.pathname.slice(0, -1);
+    console.log('Removing the slash at the end of GRAFANA_URL');
+  }
+  let finalUrl = `${urlObj.protocol}//${urlObj.hostname}`;
+  if(urlObj.port !== '') {
+    finalUrl = finalUrl + ':' + urlObj.port;
+  }
+  if(urlObj.pathname !== '') {
+    finalUrl = finalUrl + urlObj.pathname;
+  }
+  return finalUrl;
+}


### PR DESCRIPTION
closes https://github.com/hastic/hastic-server/issues/416

`GRAFANA_URL` field in config.json is now much more flexible and accepts various inputs.
- no protocol
- no slashes
- slashes at the end of input

Needs tests -> WIP