### PR TITLE
Analytic units' panel fields are not saved to db #523

### DIFF
--- a/server/src/controllers/analytics_controller.ts
+++ b/server/src/controllers/analytics_controller.ts
@@ -199,6 +199,7 @@ export async function runLearning(id: AnalyticUnit.AnalyticUnitId) {
       await AnalyticUnitCache.create(id);
     }
 
+    // TODO: create analytics serialization method in AnalyticUnit
     let analyticUnitType = analyticUnit.type;
     let detector = AnalyticUnit.getDetectorByType(analyticUnitType);
     let taskPayload: any = { detector, analyticUnitType, cache: oldCache };
@@ -389,8 +390,8 @@ export async function createAnalyticUnitFromObject(obj: any): Promise<AnalyticUn
   if(obj.datasource !== undefined) {
     obj.metric.datasource = obj.datasource;
   }
-  let unit: AnalyticUnit.AnalyticUnit = AnalyticUnit.AnalyticUnit.fromObject(obj);
-  let id = await AnalyticUnit.create(unit);
+  const unit: AnalyticUnit.AnalyticUnit = AnalyticUnit.AnalyticUnit.fromObject(obj);
+  const id = await AnalyticUnit.create(unit);
 
   return id;
 }

--- a/server/src/controllers/analytics_controller.ts
+++ b/server/src/controllers/analytics_controller.ts
@@ -199,7 +199,7 @@ export async function runLearning(id: AnalyticUnit.AnalyticUnitId) {
       await AnalyticUnitCache.create(id);
     }
 
-    // TODO: create analytics serialization method in AnalyticUnit
+    // TODO: create an analytics serialization method in AnalyticUnit
     let analyticUnitType = analyticUnit.type;
     let detector = AnalyticUnit.getDetectorByType(analyticUnitType);
     let taskPayload: any = { detector, analyticUnitType, cache: oldCache };

--- a/server/src/models/analytic_unit_model.ts
+++ b/server/src/models/analytic_unit_model.ts
@@ -115,7 +115,11 @@ export class AnalyticUnit {
       alert: this.alert,
       lastDetectionTime: this.lastDetectionTime,
       status: this.status,
-      error: this.error
+      error: this.error,
+      labeledColor: this.labeledColor,
+      deletedColor: this.deletedColor,
+      detectorType: this.detectorType,
+      visible: this.visible
     };
   }
 


### PR DESCRIPTION
Fixes #523 

Changes:
- Make `toObject()` `AnalyticUnit`'s method return all the fields
