### PR TITLE
Error: index out of bounds

### DIFF
--- a/analytics/analytics/models/model.py
+++ b/analytics/analytics/models/model.py
@@ -76,12 +76,16 @@ class Model(ABC):
             if segment_map['labeled'] or segment_map['deleted']:
                 segment = Segment(dataframe, segment_map, self.find_segment_center)
                 if segment.percent_of_nans > 0.1 or len(segment.data) == 0:
+                    logging.debug(f'segment {segment_map.start}-{segment_map.end} skip because of invalid data')
                     continue
                 if segment.percent_of_nans > 0:
                     segment.convert_nan_to_zero()
                 max_length = max(segment.length, max_length)
                 if segment.labeled: labeled.append(segment)
                 if segment.deleted: deleted.append(segment)
+
+        assert len(labeled) > 0, f'labeled list empty, skip fitting for {id}'
+
         if self.state.get('WINDOW_SIZE') == 0:            
             self.state['WINDOW_SIZE'] = math.ceil(max_length / 2) if max_length else 0
         model, model_type = self.get_model_type()

--- a/analytics/analytics/utils/dataframe.py
+++ b/analytics/analytics/utils/dataframe.py
@@ -22,6 +22,8 @@ def get_intersected_chunks(data: list, intersection: int, chunk_size: int) -> Ge
         intersection - length of intersection.
         chunk_size - length of chunk
         """
+        assert chunk_size > 0, 'chunk size must be great than zero'
+        assert intersection > 0, 'intersection length must be great than zero'
 
         data_len = len(data)
 
@@ -48,6 +50,7 @@ def get_chunks(data: list, chunk_size: int) -> Generator[list, None, None]:
     Returns generator that splits dataframe on non-intersected segments.
     chunk_size - length of chunk
     """
+    assert chunk_size > 0, 'chunk size must be great than zero'
 
     chunks_iterables = [iter(data)] * chunk_size
     result_chunks = zip(*chunks_iterables)

--- a/analytics/tests/test_dataset.py
+++ b/analytics/tests/test_dataset.py
@@ -20,12 +20,12 @@ class TestDataset(unittest.TestCase):
             models.PeakModel(),
             models.TroughModel()
         ]
-        try:
-            for model in model_instances:
-                model_name = model.__class__.__name__
+
+        for model in model_instances:
+            model_name = model.__class__.__name__
+
+            with self.assertRaises(AssertionError):
                 model.fit(dataframe, segments, 'test', dict())
-        except ValueError:
-            self.fail('Model {} raised unexpectedly'.format(model_name))
     
     def test_peak_antisegments(self):
         data_val = [1.0, 1.0, 1.0, 2.0, 3.0, 2.0, 1.0, 1.0, 1.0, 1.0, 5.0, 7.0, 5.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0]


### PR DESCRIPTION
fixes #536 

bug occur when we skip all segments in `fit` method in model.py because of percent_of_nans more than 0.1. in this case we pass empty `labeled`list to `get_parameters_from_segments`

Changes:
- added raising exception when list of labeled segments is empty
- added assertions to dataframe chunkers