### PR TITLE
VSCode remote debugging via ptvsd

### DIFF
--- a/analytics/.vscode/launch.json
+++ b/analytics/.vscode/launch.json
@@ -5,6 +5,19 @@
     "version": "0.2.0",
     "configurations": [
         {
+            "name": "Attach (Remote Debug)",
+            "type": "python",
+            "request": "attach",
+            "port": 5679,
+            "host": "localhost",
+            "pathMappings": [
+                {
+                    "localRoot": "${workspaceFolder}",
+                    "remoteRoot": "/var/www/analytics"
+                }
+            ]
+        },
+        {
             "name": "Python: Current File",
             "type": "python",
             "request": "launch",

--- a/analytics/requirements.txt
+++ b/analytics/requirements.txt
@@ -16,3 +16,4 @@ scipy==1.1.0
 seglearn==0.1.6
 six==1.11.0
 tsfresh==0.11.0
+ptvsd==4.2.6


### PR DESCRIPTION
For remote debugging:
- make ssh tunell via `ssh -fNL 5679:localhost:5678 <server>` (you should have ssh config with `ServerAliveInterval`)
- run in vscode debug tab `attach to remote` for analytics

Changes:
- added configuration for remote debugging from vscode
- added pip package `ptvsd` for vscode debugging