### PR TITLE
rm tsfresh from deps

### DIFF
--- a/analytics/requirements.txt
+++ b/analytics/requirements.txt
@@ -15,5 +15,4 @@ scikit-learn==0.19.1
 scipy==1.1.0
 seglearn==0.1.6
 six==1.11.0
-tsfresh==0.11.0
 ptvsd==4.2.6


### PR DESCRIPTION
We don't use tsfresh in analytics, but it is in deps.
This PS remove the dependency from `analytics/requirements.txt`