### PR TITLE
Hastic instance name

### DIFF
--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -35,6 +35,7 @@ export const INSIDE_DOCKER = process.env.INSIDE_DOCKER !== undefined;
 export const PRODUCTION_MODE = process.env.NODE_ENV !== 'development';
 
 export const ZMQ_CONNECTION_STRING = createZMQConnectionString();
+export const HASTIC_INSTANCE_NAME = getConfigField('HASTIC_INSTANCE_NAME', null);
 
 
 function getConfigField(field: string, defaultVal?: any) {

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -35,7 +35,7 @@ export const INSIDE_DOCKER = process.env.INSIDE_DOCKER !== undefined;
 export const PRODUCTION_MODE = process.env.NODE_ENV !== 'development';
 
 export const ZMQ_CONNECTION_STRING = createZMQConnectionString();
-export const HASTIC_INSTANCE_NAME = getConfigField('HASTIC_INSTANCE_NAME', null);
+export const HASTIC_INSTANCE_NAME = getConfigField('HASTIC_INSTANCE_NAME', os.hostname());
 
 
 function getConfigField(field: string, defaultVal?: any) {

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -6,7 +6,7 @@ import * as AnalyticsController from './controllers/analytics_controller';
 
 import * as ProcessService from './services/process_service';
 
-import { HASTIC_PORT, PACKAGE_VERSION, GIT_INFO, ZMQ_CONNECTION_STRING } from './config';
+import { HASTIC_PORT, PACKAGE_VERSION, GIT_INFO, ZMQ_CONNECTION_STRING, HASTIC_INSTANCE_NAME } from './config';
 
 import { convertPanelUrlToPanelId } from './migrations/0.3.2-beta';
 
@@ -66,6 +66,7 @@ async function init() {
         lastAlive: AnalyticsController.analyticsLastAlive(),
         tasksQueueLength: AnalyticsController.getQueueLength()
       },
+      instanceName: HASTIC_INSTANCE_NAME,
       awaitedTasksNumber: AnalyticsController.getTaskResolversLength(),
       detectionsCount: AnalyticsController.getDetectionsCount(),
       nodeVersion: process.version,

--- a/server/src/services/notification_service.ts
+++ b/server/src/services/notification_service.ts
@@ -4,7 +4,6 @@ import { HASTIC_WEBHOOK_URL, HASTIC_WEBHOOK_TYPE, HASTIC_WEBHOOK_SECRET, HASTIC_
 
 import axios from 'axios';
 import * as querystring from 'querystring';
-import * as _ from 'lodash';
 
 enum ContentType {
   JSON = 'application/json',

--- a/server/src/services/notification_service.ts
+++ b/server/src/services/notification_service.ts
@@ -1,9 +1,10 @@
 import { Segment } from '../models/segment_model';
 import * as AnalyticUnit from '../models/analytic_unit_model';
-import { HASTIC_WEBHOOK_URL, HASTIC_WEBHOOK_TYPE, HASTIC_WEBHOOK_SECRET } from '../config';
+import { HASTIC_WEBHOOK_URL, HASTIC_WEBHOOK_TYPE, HASTIC_WEBHOOK_SECRET, HASTIC_INSTANCE_NAME } from '../config';
 
 import axios from 'axios';
 import * as querystring from 'querystring';
+import * as _ from 'lodash';
 
 enum ContentType {
   JSON = 'application/json',
@@ -67,6 +68,8 @@ export async function sendWebhook(payload: any, contentType = HASTIC_WEBHOOK_TYP
   if(HASTIC_WEBHOOK_URL === null) {
     throw new Error(`Can't send alert, HASTIC_WEBHOOK_URL is undefined`);
   }
+
+  payload.instanceName = HASTIC_INSTANCE_NAME;
 
   // TODO: use HASTIC_WEBHOOK_SECRET
   const options = {

--- a/tools/prometheus-hastic-exporter/prometheus-hastic-exporter.py
+++ b/tools/prometheus-hastic-exporter/prometheus-hastic-exporter.py
@@ -23,7 +23,12 @@ class JsonCollector(object):
     
     commitHash = response.get('git', {}).get('commitHash')
     packageVersion = response.get('packageVersion')
-    labels={'commitHash': commitHash, 'packageVersion': packageVersion}
+    instanceName = response.get('instanceName')
+    labels = {
+      'commitHash': commitHash,
+      'packageVersion': packageVersion,
+      'instanceName': instanceName
+    }
 
     metrics = {
         'activeWebhooks': response.get('activeWebhooks'),

--- a/tools/prometheus-hastic-exporter/prometheus-hastic-exporter.py
+++ b/tools/prometheus-hastic-exporter/prometheus-hastic-exporter.py
@@ -21,14 +21,16 @@ class JsonCollector(object):
         print('got exception, skip polling loop {}'.format(e))
         return
     
-    commitHash = response.get('git', {}).get('commitHash')
-    packageVersion = response.get('packageVersion')
-    instanceName = response.get('instanceName')
-    labels = {
-      'commitHash': commitHash,
-      'packageVersion': packageVersion,
-      'instanceName': instanceName
+    labels_values = {
+        'commitHash': response.get('git', {}).get('commitHash'),
+        'packageVersion': response.get('packageVersion'),
+        'instanceName': response.get('instanceName1')
     }
+
+    labels = {}
+    for k, v in labels_values.items():
+        if v is not None:
+            labels[k] = v
 
     metrics = {
         'activeWebhooks': response.get('activeWebhooks'),


### PR DESCRIPTION
fixes #547 

changes:
- added `instanceName` field to server info and webhook payload
- added label `instanceName` to `prometheus-hastic-exporter`