### PR TITLE
Don't run detection if learning failed #549

### DIFF
--- a/server/src/controllers/analytics_controller.ts
+++ b/server/src/controllers/analytics_controller.ts
@@ -229,8 +229,9 @@ export async function runLearning(id: AnalyticUnit.AnalyticUnitId) {
     }
     await AnalyticUnitCache.setData(id, result.payload.cache);
   } catch (err) {
-    let message = err.message || JSON.stringify(err);
+    const message = err.message || JSON.stringify(err);
     await AnalyticUnit.setStatus(id, AnalyticUnit.AnalyticUnitStatus.FAILED, message);
+    throw new Error(message)
   }
 
 }
@@ -433,5 +434,6 @@ export async function runFirstLearning(id: AnalyticUnit.AnalyticUnitId) {
   // TODO: move setting status somehow "inside" learning
   await AnalyticUnit.setStatus(id, AnalyticUnit.AnalyticUnitStatus.PENDING);
   runLearning(id)
-    .then(() => runDetect(id));
+    .then(() => runDetect(id))
+    .catch(err => console.error(err));
 }

--- a/server/src/controllers/analytics_controller.ts
+++ b/server/src/controllers/analytics_controller.ts
@@ -430,7 +430,7 @@ export async function updateThreshold(
   await Threshold.updateThreshold(id, value, condition);
 }
 
-export async function runFirstLearning(id: AnalyticUnit.AnalyticUnitId) {
+export async function runLearningWithDetection(id: AnalyticUnit.AnalyticUnitId) {
   // TODO: move setting status somehow "inside" learning
   await AnalyticUnit.setStatus(id, AnalyticUnit.AnalyticUnitStatus.PENDING);
   runLearning(id)

--- a/server/src/routes/analytic_units_router.ts
+++ b/server/src/routes/analytic_units_router.ts
@@ -125,7 +125,7 @@ async function deleteUnit(ctx: Router.IRouterContext) {
 async function runDetect(ctx: Router.IRouterContext) {
   const { ids } = ctx.request.body as { ids: AnalyticUnit.AnalyticUnitId[] };
 
-  await Promise.all(ids.map(AnalyticsController.runFirstLearning));
+  await Promise.all(ids.map(AnalyticsController.runLearningWithDetection));
 
   ctx.response.body = {
     code: 200,


### PR DESCRIPTION
Fixes #549 

Learning doesn't throw any exception on failure
Thus, detection starts even if something goes wrong

Changes:
- throw exception when learning fails (it stops detection from running)
- rename `runFirstLearning` to `runLearningWithDetection`