### PR TITLE
Sort analytic units by creation date / name #514

### DIFF
--- a/server/src/models/analytic_unit_model.ts
+++ b/server/src/models/analytic_unit_model.ts
@@ -174,7 +174,7 @@ export async function findById(id: AnalyticUnitId): Promise<AnalyticUnit> {
 }
 
 export async function findMany(query: FindManyQuery): Promise<AnalyticUnit[]> {
-  let analyticUnits = await db.findMany(query);
+  const analyticUnits = await db.findMany(query, { createdAt: 1, name: 1 });
   if(analyticUnits === null) {
     return [];
   }

--- a/server/src/models/analytic_unit_model.ts
+++ b/server/src/models/analytic_unit_model.ts
@@ -1,4 +1,4 @@
-import { Collection, makeDBQ } from '../services/data_service';
+import { Collection, makeDBQ, SortingOrder } from '../services/data_service';
 
 import { Metric } from 'grafana-datasource-kit';
 
@@ -174,7 +174,10 @@ export async function findById(id: AnalyticUnitId): Promise<AnalyticUnit> {
 }
 
 export async function findMany(query: FindManyQuery): Promise<AnalyticUnit[]> {
-  const analyticUnits = await db.findMany(query, { createdAt: 1, name: 1 });
+  const analyticUnits = await db.findMany(query, {
+    createdAt: SortingOrder.ASCENDING,
+    name: SortingOrder.ASCENDING
+  });
   if(analyticUnits === null) {
     return [];
   }

--- a/server/src/services/data_service.ts
+++ b/server/src/services/data_service.ts
@@ -14,7 +14,7 @@ export enum Collection { ANALYTIC_UNITS, ANALYTIC_UNIT_CACHES, SEGMENTS, THRESHO
  */
 export type DBQ = {
   findOne: (query: string | object) => Promise<any | null>,
-  findMany: (query: string[] | object) => Promise<any[]>,
+  findMany: (query: string[] | object, sortQuery?: object) => Promise<any[]>,
   insertOne: (document: object) => Promise<string>,
   insertMany: (documents: object[]) => Promise<string[]>,
   updateOne: (query: string | object, updateQuery: any) => Promise<any>,
@@ -142,13 +142,13 @@ let dbFindOne = (collection: Collection, query: string | object) => {
   });
 }
 
-let dbFindMany = (collection: Collection, query: string[] | object) => {
+let dbFindMany = (collection: Collection, query: string[] | object, sortQuery: object = {}) => {
   if(isEmptyArray(query)) {
     return Promise.resolve([]);
   }
   query = wrapIdsToQuery(query);
   return new Promise<any[]>((resolve, reject) => {
-    db.get(collection).find(query, (err, docs: any[]) => {
+    db.get(collection).find(query).sort(sortQuery).exec((err, docs: any[]) => {
       if(err) {
         reject(err);
       } else {

--- a/server/src/services/data_service.ts
+++ b/server/src/services/data_service.ts
@@ -6,6 +6,7 @@ import * as fs from 'fs';
 
 export enum Collection { ANALYTIC_UNITS, ANALYTIC_UNIT_CACHES, SEGMENTS, THRESHOLD };
 
+export enum SortingOrder { ASCENDING = 1, DESCENDING = -1 };
 
 /**
  * Class which helps to make queries to your collection

--- a/server/src/services/data_service.ts
+++ b/server/src/services/data_service.ts
@@ -208,7 +208,7 @@ function checkDataFolders(): void {
 checkDataFolders();
 
 // TODO: it's better if models request db which we create if it`s needed
-db.set(Collection.ANALYTIC_UNITS, new nedb({ filename: config.ANALYTIC_UNITS_DATABASE_PATH, autoload: true }));
+db.set(Collection.ANALYTIC_UNITS, new nedb({ filename: config.ANALYTIC_UNITS_DATABASE_PATH, autoload: true, timestampData: true }));
 db.set(Collection.ANALYTIC_UNIT_CACHES, new nedb({ filename: config.ANALYTIC_UNIT_CACHES_DATABASE_PATH, autoload: true }));
 db.set(Collection.SEGMENTS, new nedb({ filename: config.SEGMENTS_DATABASE_PATH, autoload: true }));
 db.set(Collection.THRESHOLD, new nedb({ filename: config.THRESHOLD_DATABASE_PATH, autoload: true }));


### PR DESCRIPTION
Closes #514 

Changes:
- Add `timestampData` option to db init (https://github.com/louischatriot/nedb#creatingloading-a-database)
![image](https://user-images.githubusercontent.com/1989898/56213939-9d633a00-6065-11e9-81b1-1d8dd6bcb8b6.png)
- Add sorting query to `dbFindMany`
- Use sorting query in `AnalyticUnit.findMany` (sort by `createdAt` and `name` fields)