### PR TITLE
ValueError: array must not contain infs or NaNs #563

### DIFF
--- a/analytics/analytics/utils/common.py
+++ b/analytics/analytics/utils/common.py
@@ -309,6 +309,7 @@ def get_correlation(segments: list, av_model: list, data: pd.Series, window_size
     return correlation_list
 
 def get_distribution_density(segment: pd.Series) -> float:
+    segment.dropna(inplace = True)
     if len(segment) < 2 or len(segment.nonzero()[0]) == 0:
         return (0, 0, 0)
     min_jump = min(segment)

--- a/analytics/tests/test_utils.py
+++ b/analytics/tests/test_utils.py
@@ -195,6 +195,12 @@ class TestUtils(unittest.TestCase):
         utils_result_segment = utils.get_distribution_density(segment)
         self.assertEqual(len(utils_result_data), 3)
         self.assertEqual(utils_result_segment, (0, 0, 0))
+
+    def test_get_distribution_density_with_nans(self):
+        segment = [np.NaN, 1, 1, 1, np.NaN, 3, 5, 5, 5, np.NaN]
+        segment = pd.Series(segment)
+        result = (3, 5, 1)
+        self.assertEqual(utils.get_distribution_density(segment), result)
     
     def test_find_pattern_jump_center(self):
         data = [1.0, 1.0, 1.0, 5.0, 5.0, 5.0]


### PR DESCRIPTION
Fixes #563 

Exception was thrown because we can't get distribution density if there are `NaN` values in a segment
We can safely drop them to fix this issue

Changes:
- Drop `NaN`s from segment in `get_distribution_density`
- Add test with `NaN`s 