### PR TITLE
Thresholds error: from is NaN #621

### DIFF
--- a/server/src/controllers/analytics_controller.ts
+++ b/server/src/controllers/analytics_controller.ts
@@ -474,6 +474,10 @@ export async function runLearningWithDetection(
 ): Promise<void> {
   // TODO: move setting status somehow "inside" learning
   await AnalyticUnit.setStatus(id, AnalyticUnit.AnalyticUnitStatus.PENDING);
+  const foundSegments = await Segment.findMany(id, { labeled: false, deleted: false });
+  if(foundSegments !== null) {
+    await Segment.removeSegments(foundSegments.map(segment => segment.id));
+  }
   await Detection.clearSpans(id);
   runLearning(id, from, to)
     .then(() => runDetect(id, from, to))

--- a/server/src/controllers/analytics_controller.ts
+++ b/server/src/controllers/analytics_controller.ts
@@ -22,6 +22,8 @@ const SECONDS_IN_MINUTE = 60;
 
 type TaskResult = any;
 type DetectionResult = any;
+// TODO: move type definitions somewhere
+type TimeRange = { from: number, to: number };
 export type TaskResolver = (taskResult: TaskResult) => void;
 
 const taskResolvers = new Map<AnalyticsTaskId, TaskResolver>();
@@ -113,7 +115,7 @@ async function runTask(task: AnalyticsTask): Promise<TaskResult> {
 async function getQueryRange(
   analyticUnitId: AnalyticUnit.AnalyticUnitId,
   detectorType: AnalyticUnit.DetectorType
-): Promise<{ from: number, to: number }> {
+): Promise<TimeRange> {
   if(detectorType === AnalyticUnit.DetectorType.PATTERN) {
     // TODO: find labeled OR deleted segments to generate timerange
     const segments = await Segment.findMany(analyticUnitId, { labeled: true });
@@ -137,7 +139,7 @@ async function getQueryRange(
 
 async function query(
   analyticUnit: AnalyticUnit.AnalyticUnit,
-  range: { from: number, to: number }
+  range: TimeRange
 ) {
   console.log(`query time range: from ${new Date(range.from)} to ${new Date(range.to)}`);
 
@@ -232,7 +234,7 @@ export async function runLearning(id: AnalyticUnit.AnalyticUnitId, from?: number
       };
     }
 
-    let range;
+    let range: TimeRange;
     if(from !== undefined && to !== undefined) {
       range = { from, to };
     } else {
@@ -267,7 +269,7 @@ export async function runDetect(id: AnalyticUnit.AnalyticUnitId, from?: number, 
     let analyticUnitType = unit.type;
     let detector = AnalyticUnit.getDetectorByType(analyticUnitType);
 
-    let range;
+    let range: TimeRange;
     if(from !== undefined && to !== undefined) {
       range = { from, to };
     } else {

--- a/server/src/controllers/analytics_controller.ts
+++ b/server/src/controllers/analytics_controller.ts
@@ -192,7 +192,7 @@ function getQueryRangeForLearningBySegments(segments: Segment.Segment[]) {
   return { from, to };
 }
 
-export async function runLearning(id: AnalyticUnit.AnalyticUnitId) {
+export async function runLearning(id: AnalyticUnit.AnalyticUnitId, from?: number, to?: number) {
   console.log('learning started...');
   try {
 
@@ -232,7 +232,12 @@ export async function runLearning(id: AnalyticUnit.AnalyticUnitId) {
       };
     }
 
-    const range = await getQueryRange(id, detector);
+    let range;
+    if(from !== undefined && to !== undefined) {
+      range = { from, to };
+    } else {
+      range = await getQueryRange(id, detector);
+    }
     taskPayload.data = await query(analyticUnit, range);
 
     let task = new AnalyticsTask(
@@ -462,12 +467,16 @@ export async function updateSegments(
   return { addedIds };
 }
 
-export async function runLearningWithDetection(id: AnalyticUnit.AnalyticUnitId) {
+export async function runLearningWithDetection(
+  id: AnalyticUnit.AnalyticUnitId,
+  from?: number,
+  to?: number
+): Promise<void> {
   // TODO: move setting status somehow "inside" learning
   await AnalyticUnit.setStatus(id, AnalyticUnit.AnalyticUnitStatus.PENDING);
   await Detection.clearSpans(id);
-  runLearning(id)
-    .then(() => runDetect(id))
+  runLearning(id, from, to)
+    .then(() => runDetect(id, from, to))
     .catch(err => console.error(err));
 }
 

--- a/server/src/models/analytic_unit_cache_model.ts
+++ b/server/src/models/analytic_unit_cache_model.ts
@@ -1,6 +1,8 @@
 import { AnalyticUnitId } from './analytic_units';
 import { Collection, makeDBQ } from '../services/data_service';
 
+import * as _ from 'lodash';
+
 
 const db = makeDBQ(Collection.ANALYTIC_UNIT_CACHES);
 // TODO: count milliseconds in index from dataset
@@ -31,7 +33,7 @@ export class AnalyticUnitCache {
   }
 
   public getIntersection(): number {
-    if(this.data !== undefined && this.data !== null) {
+    if(_.has(this.data, 'windowSize')) {
       //TODO: return one window size after resolving https://github.com/hastic/hastic-server/issues/508
       return this.data.windowSize * 2 * MILLISECONDS_IN_INDEX;
     }

--- a/server/src/routes/analytic_units_router.ts
+++ b/server/src/routes/analytic_units_router.ts
@@ -123,9 +123,11 @@ async function deleteUnit(ctx: Router.IRouterContext) {
 }
 
 async function runDetect(ctx: Router.IRouterContext) {
-  const { ids } = ctx.request.body as { ids: AnalyticUnit.AnalyticUnitId[] };
+  const { ids, from, to } = ctx.request.body as {
+    ids: AnalyticUnit.AnalyticUnitId[], from: number, to: number
+  };
 
-  await Promise.all(ids.map(AnalyticsController.runLearningWithDetection));
+  await Promise.all(ids.map(id => AnalyticsController.runLearningWithDetection(id, from, to)));
 
   ctx.response.body = {
     code: 200,


### PR DESCRIPTION
Fixes #621 

The error occurred because of missing `windowSize` field in Threshold`s detection cache 

Changes:
- use `from` and `to` in learning and detection if they're provided 
- check if `cache` has `windowSize`
- remove previously found segments before learning 