### PR TITLE
Basic anomaly model in hastic-node

### DIFF
--- a/server/src/models/analytic_units/anomaly_analytic_unit_model.ts
+++ b/server/src/models/analytic_units/anomaly_analytic_unit_model.ts
@@ -1,0 +1,86 @@
+import { AnalyticUnit } from './analytic_unit_model';
+import { AnalyticUnitId, AnalyticUnitStatus, DetectorType } from './types';
+
+import { Metric } from 'grafana-datasource-kit';
+
+
+export class AnomalyAnalyticUnit extends AnalyticUnit {
+  constructor(
+    name: string,
+    grafanaUrl: string,
+    panelId: string,
+    type: string,
+    public alpha: number,
+    public confidence: number,
+    metric?: Metric,
+    alert?: boolean,
+    id?: AnalyticUnitId,
+    lastDetectionTime?: number,
+    status?: AnalyticUnitStatus,
+    error?: string,
+    labeledColor?: string,
+    deletedColor?: string,
+    visible?: boolean
+  ) {
+    super(
+      name,
+      grafanaUrl,
+      panelId,
+      type,
+      metric,
+      alert,
+      id,
+      lastDetectionTime,
+      status,
+      error,
+      labeledColor,
+      deletedColor,
+      DetectorType.THRESHOLD,
+      visible
+    );
+  }
+
+  toObject() {
+    const baseObject = super.toObject();
+    return {
+      ...baseObject,
+      alpha: this.alpha,
+      confidence: this.confidence
+    };
+  }
+
+  toPanelObject() {
+    const baseObject = super.toPanelObject();
+    return {
+      ...baseObject,
+      alpha: this.alpha,
+      confidence: this.confidence
+    };
+  }
+
+  static fromObject(obj: any) {
+    // TODO: remove duplication
+    let metric: Metric;
+    if (obj.metric !== undefined) {
+      metric = Metric.fromObject(obj.metric);
+    }
+
+    return new AnomalyAnalyticUnit(
+      obj.name,
+      obj.grafanaUrl,
+      obj.panelId,
+      obj.type,
+      obj.alpha,
+      obj.confidence,
+      metric,
+      obj.alert,
+      obj._id,
+      obj.lastDetectionTime,
+      obj.status,
+      obj.error,
+      obj.labeledColor,
+      obj.deletedColor,
+      obj.visible
+    );
+  }
+}

--- a/server/src/models/analytic_units/types.ts
+++ b/server/src/models/analytic_units/types.ts
@@ -50,6 +50,12 @@ export const ANALYTIC_UNIT_TYPES = {
       value: 'DROP'
     }
   ],
+  anomaly: [
+    {
+      name: 'Anomaly',
+      value: 'ANOMALY'
+    }
+  ],
   threshold: [
     {
       name: 'Threshold',
@@ -60,5 +66,6 @@ export const ANALYTIC_UNIT_TYPES = {
 
 export enum DetectorType {
   PATTERN = 'pattern',
+  ANOMALY = 'anomaly',
   THRESHOLD = 'threshold'
 };

--- a/server/src/models/analytic_units/utils.ts
+++ b/server/src/models/analytic_units/utils.ts
@@ -1,6 +1,7 @@
 import { DetectorType, ANALYTIC_UNIT_TYPES } from './types';
 import { AnalyticUnit } from './analytic_unit_model';
 import { PatternAnalyticUnit } from './pattern_analytic_unit_model';
+import { AnomalyAnalyticUnit } from './anomaly_analytic_unit_model';
 import { ThresholdAnalyticUnit } from './threshold_analytic_unit_model';
 
 import * as _ from 'lodash';
@@ -15,6 +16,8 @@ export function createAnalyticUnitFromObject(obj: any): AnalyticUnit {
   switch (detectorType) {
     case DetectorType.PATTERN:
       return PatternAnalyticUnit.fromObject(obj);
+    case DetectorType.ANOMALY:
+      return AnomalyAnalyticUnit.fromObject(obj)
     case DetectorType.THRESHOLD:
       return ThresholdAnalyticUnit.fromObject(obj);
 


### PR DESCRIPTION
Closes https://github.com/hastic/hastic-server/issues/629

This PR contains basic implementation of a new Anomaly class, `AnomalyAnalyticUnit` which is the starting point for new detector in analytics. 

Now it's possible to create anomaly:
![image](https://user-images.githubusercontent.com/1022757/57194901-09460d80-6f55-11e9-92ed-1338e4798e95.png)
