### PR TITLE
detectorType field is missing in old analytic units #632

### DIFF
--- a/server/src/controllers/analytics_controller.ts
+++ b/server/src/controllers/analytics_controller.ts
@@ -212,7 +212,7 @@ export async function runLearning(id: AnalyticUnit.AnalyticUnitId, from?: number
 
     // TODO: create an analytics serialization method in AnalyticUnit
     let analyticUnitType = analyticUnit.type;
-    let detector = AnalyticUnit.getDetectorByType(analyticUnitType);
+    const detector = analyticUnit.detectorType;
     let taskPayload: any = { detector, analyticUnitType, cache: oldCache };
 
     if(detector === AnalyticUnit.DetectorType.PATTERN) {
@@ -267,7 +267,7 @@ export async function runDetect(id: AnalyticUnit.AnalyticUnitId, from?: number, 
     let unit = await AnalyticUnit.findById(id);
     previousLastDetectionTime = unit.lastDetectionTime;
     let analyticUnitType = unit.type;
-    let detector = AnalyticUnit.getDetectorByType(analyticUnitType);
+    const detector = unit.detectorType;
 
     let range: TimeRange;
     if(from !== undefined && to !== undefined) {

--- a/server/src/migrations.ts
+++ b/server/src/migrations.ts
@@ -3,10 +3,11 @@
   - create migration function
   - add it with the next revision number to REVISIONS Map
   It will be automatically applied if actual DB revision < added revision
+
+  Note: do not import code from other modules here because it can be changed
 */
 
 import { Collection, makeDBQ } from './services/data_service';
-import { getDetectorByType } from './models/analytic_units';
 
 import * as _ from 'lodash';
 
@@ -126,4 +127,24 @@ async function addDetectorTypes() {
   );
 
   await Promise.all(promises);
+}
+
+function getDetectorByType(analyticUnitType: string): string {
+  const analyticUnitTypesMapping = {
+    pattern: [ 'GENERAL', 'PEAK', 'TROUGH', 'JUMP', 'DROP' ],
+    anomaly: [ 'ANOMALY' ],
+    threshold: [ 'THRESHOLD' ]
+  };
+
+  let detector;
+  _.forOwn(analyticUnitTypesMapping, (types, detectorType) => {
+    if(types.includes(analyticUnitType)) {
+      detector = detectorType;
+    }
+  });
+
+  if(detector === undefined) {
+    throw new Error(`Can't find detector for analytic unit of type "${analyticUnitType}"`);
+  }
+  return detector;
 }

--- a/server/src/models/analytic_units/index.ts
+++ b/server/src/models/analytic_units/index.ts
@@ -1,4 +1,4 @@
-import { createAnalyticUnitFromObject, getDetectorByType } from './utils';
+import { createAnalyticUnitFromObject } from './utils';
 import { AnalyticUnitId, AnalyticUnitStatus, DetectorType, ANALYTIC_UNIT_TYPES } from './types';
 import { AnalyticUnit } from './analytic_unit_model';
 import { PatternAnalyticUnit } from './pattern_analytic_unit_model';
@@ -19,7 +19,7 @@ import {
 export {
   AnalyticUnit, PatternAnalyticUnit, ThresholdAnalyticUnit,
   AnalyticUnitId, AnalyticUnitStatus, DetectorType, ANALYTIC_UNIT_TYPES,
-  createAnalyticUnitFromObject, getDetectorByType,
+  createAnalyticUnitFromObject,
   findById, findMany,
   create, remove, update,
   setStatus, setDetectionTime, setAlert, setMetric

--- a/server/src/models/analytic_units/utils.ts
+++ b/server/src/models/analytic_units/utils.ts
@@ -25,17 +25,3 @@ export function createAnalyticUnitFromObject(obj: any): AnalyticUnit {
       throw new Error(`Can't create analytic unit with type "${detectorType}"`);
   }
 }
-
-export function getDetectorByType(analyticUnitType: string): DetectorType {
-  let detector;
-  _.forOwn(ANALYTIC_UNIT_TYPES, (types, detectorType) => {
-    if(_.find(types, { value: analyticUnitType }) !== undefined) {
-      detector = detectorType;
-    }
-  });
-
-  if(detector === undefined) {
-    throw new Error(`Can't find detector for analytic unit of type "${analyticUnitType}"`);
-  }
-  return detector;
-}

--- a/server/src/services/alert_service.ts
+++ b/server/src/services/alert_service.ts
@@ -131,7 +131,7 @@ export class AlertService {
   }
 
   public addAnalyticUnit(analyticUnit: AnalyticUnit.AnalyticUnit) {
-    let detector = AnalyticUnit.getDetectorByType(analyticUnit.type);
+    const detector = analyticUnit.detectorType;
     let alertsType = {};
 
     alertsType[AnalyticUnit.DetectorType.THRESHOLD] = ThresholdAlert;

--- a/server/src/services/data_puller.ts
+++ b/server/src/services/data_puller.ts
@@ -135,7 +135,7 @@ export class DataPuller {
       if(cache !== null) {
         cache = cache.data
       }
-      const detector = AnalyticUnit.getDetectorByType(analyticUnit.type);
+      const detector = analyticUnit.detectorType;
       let payload = {
         data: payloadValues,
         from: this._unitTimes[analyticUnit.id],


### PR DESCRIPTION
Fixes #632 

Changes:
- add migration which adds `detectorType` field to all analytic units
- move `getDetectorByType()` to `migrations.ts`
- use `analyticUnit.detectorType` instead of `getDetectorByType(analyticUnit.type)` everywhere