### PR TITLE
HASTIC_PORT in .env file #640

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       GRAFANA_URL: ${GRAFANA_URL}
       HASTIC_INSTANCE_NAME: ${HASTIC_INSTANCE_NAME}
     ports:
-      - 8000:8000
+      - ${HASTIC_PORT:-8000}:8000
     volumes:
       - data-volume:/var/www/data
     restart: always


### PR DESCRIPTION
Closes #640 

Now it's possible to set `HASTIC_PORT` variable in `.env` file
Compatible with old configurations: default value is 8000