### PR TITLE
Merge threshold segments #624

### DIFF
--- a/analytics/analytics/analytic_types/__init__.py
+++ b/analytics/analytics/analytic_types/__init__.py
@@ -17,7 +17,7 @@ AnalyticUnitId = str
 ModelCache = dict
 
 # TODO: explicit timestamp / value
-TimeSeries = [List[Tuple[int, int]]]
+TimeSeries = [List[Tuple[int, float]]]
 
 """
 Example:

--- a/analytics/analytics/analytic_types/__init__.py
+++ b/analytics/analytics/analytic_types/__init__.py
@@ -17,7 +17,7 @@ AnalyticUnitId = str
 ModelCache = dict
 
 # TODO: explicit timestamp / value
-TimeSeries = [List[Tuple[int, float]]]
+TimeSeries = List[Tuple[int, float]]
 
 """
 Example:

--- a/analytics/analytics/analytic_unit_worker.py
+++ b/analytics/analytics/analytic_unit_worker.py
@@ -8,7 +8,7 @@ import asyncio
 import utils
 from utils import get_intersected_chunks, get_chunks, prepare_data
 
-from analytic_types import ModelCache
+from analytic_types import ModelCache, TimeSeries
 from analytic_types.detector_typing import DetectionResult
 
 logger = logging.getLogger('AnalyticUnitWorker')
@@ -77,7 +77,7 @@ class AnalyticUnitWorker:
         if self._training_future is not None:
             self._training_future.cancel()
 
-    async def consume_data(self, data: list, cache: Optional[ModelCache]) -> Optional[dict]:
+    async def consume_data(self, data: TimeSeries, cache: Optional[ModelCache]) -> Optional[dict]:
         window_size = self._detector.get_window_size(cache)
 
         detections: List[DetectionResult] = []

--- a/analytics/analytics/analytic_unit_worker.py
+++ b/analytics/analytics/analytic_unit_worker.py
@@ -93,8 +93,7 @@ class AnalyticUnitWorker:
             return None
         else:
             time_step = utils.get_time_step(data)
-            detection_result = self._detector.concat_detection_results(
-                detections, time_step)
+            detection_result = self._detector.concat_detection_results(detections, time_step)
             return detection_result.to_json()
 
     async def process_data(self, data: list, cache: ModelCache) -> dict:

--- a/analytics/analytics/analytic_unit_worker.py
+++ b/analytics/analytics/analytic_unit_worker.py
@@ -69,7 +69,8 @@ class AnalyticUnitWorker:
         if len(detections) == 0:
             raise RuntimeError(f'do_detect for {self.analytic_unit_id} got empty detection results')
 
-        detection_result = self._detector.concat_detection_results(detections)
+        time_step = utils.get_time_step(data)
+        detection_result = self._detector.concat_detection_results(detections, time_step)
         return detection_result.to_json()
 
     def cancel(self):
@@ -91,7 +92,9 @@ class AnalyticUnitWorker:
         if len(detections) == 0:
             return None
         else:
-            detection_result = self._detector.concat_detection_results(detections)
+            time_step = utils.get_time_step(data)
+            detection_result = self._detector.concat_detection_results(
+                detections, time_step)
             return detection_result.to_json()
 
     async def process_data(self, data: list, cache: ModelCache) -> dict:

--- a/analytics/analytics/analytic_unit_worker.py
+++ b/analytics/analytics/analytic_unit_worker.py
@@ -69,7 +69,7 @@ class AnalyticUnitWorker:
         if len(detections) == 0:
             raise RuntimeError(f'do_detect for {self.analytic_unit_id} got empty detection results')
 
-        time_step = utils.get_time_step(data)
+        time_step = utils.find_interval(data)
         detection_result = self._detector.concat_detection_results(detections, time_step)
         return detection_result.to_json()
 
@@ -92,7 +92,7 @@ class AnalyticUnitWorker:
         if len(detections) == 0:
             return None
         else:
-            time_step = utils.get_time_step(data)
+            time_step = utils.find_interval(data)
             detection_result = self._detector.concat_detection_results(detections, time_step)
             return detection_result.to_json()
 

--- a/analytics/analytics/detectors/anomaly_detector.py
+++ b/analytics/analytics/detectors/anomaly_detector.py
@@ -93,13 +93,13 @@ class AnomalyDetector(ProcessingDetector):
                 break
         return level
 
-    def concat_detection_results(self, detections: List[DetectionResult]) -> DetectionResult:
+    def concat_detection_results(self, detections: List[DetectionResult], time_step: int) -> DetectionResult:
         result = DetectionResult()
         for detection in detections:
             result.segments.extend(detection.segments)
             result.last_detection_time = detection.last_detection_time
             result.cache = detection.cache
-        result.segments = utils.merge_intersecting_segments(result.segments)
+        result.segments = utils.merge_intersecting_segments(result.segments, time_step)
         return result
 
     # TODO: ModelCache -> ModelState

--- a/analytics/analytics/detectors/detector.py
+++ b/analytics/analytics/detectors/detector.py
@@ -31,7 +31,7 @@ class Detector(ABC):
     def is_detection_intersected(self) -> bool:
         return True
 
-    def concat_detection_results(self, detections: List[DetectionResult]) -> DetectionResult:
+    def concat_detection_results(self, detections: List[DetectionResult], time_step: int) -> DetectionResult:
         result = DetectionResult()
         for detection in detections:
             result.segments.extend(detection.segments)

--- a/analytics/analytics/detectors/threshold_detector.py
+++ b/analytics/analytics/detectors/threshold_detector.py
@@ -9,7 +9,7 @@ from analytic_types.detector_typing import DetectionResult
 from analytic_types.segment import Segment
 from detectors import Detector
 from time import time
-from utils
+import utils
 
 
 logger = log.getLogger('THRESHOLD_DETECTOR')

--- a/analytics/analytics/utils/common.py
+++ b/analytics/analytics/utils/common.py
@@ -128,7 +128,7 @@ def close_filtering(pattern_list: List[int], win_size: int) -> List[Tuple[int, i
             s.append([pattern_list[i]])
     return s
 
-def merge_intersecting_segments(segments: List[Segment]) -> List[Segment]:
+def merge_intersecting_segments(segments: List[Segment], time_step: int) -> List[Segment]:
     '''
     Find intersecting segments in segments list and merge it.
     '''
@@ -137,13 +137,18 @@ def merge_intersecting_segments(segments: List[Segment]) -> List[Segment]:
     segments = sorted(segments, key = lambda segment: segment.from_timestamp)
     previous_segment = segments[0]
     for i in range(1, len(segments)):
-        if segments[i].from_timestamp <= previous_segment.to_timestamp:
+        if segments[i].from_timestamp <= previous_segment.to_timestamp + time_step:
             segments[i].from_timestamp = min(previous_segment.from_timestamp, segments[i].from_timestamp)
             segments[i].to_timestamp = max(previous_segment.to_timestamp, segments[i].to_timestamp)
             segments[i - 1] = None
         previous_segment = segments[i]
     segments = [x for x in segments if x is not None]
     return segments
+
+def get_time_step(dataframe: pd.DataFrame) -> int:
+    if len(dataframe) < 2:
+        raise ValueError('Couldnt get time step from dataframe: {}'.format(dataframe))
+    return int(dataframe[1][0] - dataframe[0][0])
 
 def get_start_and_end_of_segments(segments: List[List[int]]) -> List[Tuple[int, int]]:
     '''

--- a/analytics/analytics/utils/common.py
+++ b/analytics/analytics/utils/common.py
@@ -145,10 +145,10 @@ def merge_intersecting_segments(segments: List[Segment], time_step: int) -> List
     segments = [x for x in segments if x is not None]
     return segments
 
-def find_interval(dataframe: pd.DataFrame) -> int:
-    if len(dataframe) < 2:
-        raise ValueError('Can`t find interval: length of dataframe must be at least 2')
-    return int(dataframe[1][0] - dataframe[0][0])
+def find_interval(data: List[Tuple[int, float]]) -> int:
+    if len(data) < 2:
+        raise ValueError('Can`t find interval: length of data must be at least 2')
+    return int(data[1][0] - data[0][0])
 
 def get_start_and_end_of_segments(segments: List[List[int]]) -> List[Tuple[int, int]]:
     '''

--- a/analytics/analytics/utils/common.py
+++ b/analytics/analytics/utils/common.py
@@ -11,6 +11,7 @@ import utils
 import logging
 from itertools import islice
 from collections import deque
+from analytic_types import TimeSeries
 from analytic_types.segment import Segment
 
 SHIFT_FACTOR = 0.05
@@ -145,7 +146,7 @@ def merge_intersecting_segments(segments: List[Segment], time_step: int) -> List
     segments = [x for x in segments if x is not None]
     return segments
 
-def find_interval(data: List[Tuple[int, float]]) -> int:
+def find_interval(data: TimeSeries) -> int:
     if len(data) < 2:
         raise ValueError('Can`t find interval: length of data must be at least 2')
     return int(data[1][0] - data[0][0])

--- a/analytics/analytics/utils/common.py
+++ b/analytics/analytics/utils/common.py
@@ -145,9 +145,9 @@ def merge_intersecting_segments(segments: List[Segment], time_step: int) -> List
     segments = [x for x in segments if x is not None]
     return segments
 
-def get_time_step(dataframe: pd.DataFrame) -> int:
+def find_interval(dataframe: pd.DataFrame) -> int:
     if len(dataframe) < 2:
-        raise ValueError('Couldnt get time step from dataframe: {}'.format(dataframe))
+        raise ValueError('Can`t find interval: length of dataframe must be at least 2')
     return int(dataframe[1][0] - dataframe[0][0])
 
 def get_start_and_end_of_segments(segments: List[List[int]]) -> List[Tuple[int, int]]:

--- a/analytics/tests/test_utils.py
+++ b/analytics/tests/test_utils.py
@@ -306,44 +306,58 @@ class TestUtils(unittest.TestCase):
         test_cases = [
             {
                 'index': [Segment(10, 20), Segment(30, 40)],
-                'result': [[10, 20], [30, 40]]
+                'result': [[10, 20], [30, 40]],
+                'step': 0,
             },
             {
                 'index': [Segment(10, 20), Segment(13, 23), Segment(15, 17), Segment(20, 40)],
-                'result': [[10, 40]]
+                'result': [[10, 40]],
+                'step': 0,
             },
             {
                 'index': [],
-                'result': []
+                'result': [],
+                'step': 0,
             },
             {
                 'index': [Segment(10, 20)],
-                'result': [[10, 20]]
+                'result': [[10, 20]],
+                'step': 0,
             },
             {
                 'index': [Segment(10, 20), Segment(13, 23), Segment(25, 30), Segment(35, 40)],
-                'result': [[10, 23], [25, 30], [35, 40]]
+                'result': [[10, 23], [25, 30], [35, 40]],
+                'step': 0,
             },
             {
                 'index': [Segment(10, 50), Segment(5, 40), Segment(15, 25), Segment(6, 50)],
-                'result': [[5, 50]]
+                'result': [[5, 50]],
+                'step': 0,
             },
             {
                 'index': [Segment(5, 10), Segment(10, 20), Segment(25, 50)],
-                'result': [[5, 20], [25, 50]]
+                'result': [[5, 20], [25, 50]],
+                'step': 0,
             },
             {
                 'index': [Segment(20, 40), Segment(10, 15), Segment(50, 60)],
-                'result': [[10, 15], [20, 40], [50, 60]]
+                'result': [[10, 15], [20, 40], [50, 60]],
+                'step': 0,
             },
             {
                 'index': [Segment(20, 40), Segment(10, 20), Segment(50, 60)],
-                'result': [[10, 40], [50, 60]]
+                'result': [[10, 40], [50, 60]],
+                'step': 0,
+            },
+            {
+                'index': [Segment(10, 10), Segment(20, 20), Segment(30, 30)],
+                'result': [[10, 30]],
+                'step': 10,
             },
         ]
 
         for case in test_cases:
-            utils_result = utils.merge_intersecting_segments(case['index'])
+            utils_result = utils.merge_intersecting_segments(case['index'], case['step'])
             for got, expected in zip(utils_result, case['result']):
                 self.assertEqual(got.from_timestamp, expected[0])
                 self.assertEqual(got.to_timestamp, expected[1])


### PR DESCRIPTION
Closes #624
## Problem
After the detection of threshold neighboring segments that were found did not merge. The reason - timestamps differ from each other at some step.
![image](https://user-images.githubusercontent.com/39257464/57694534-a3dcd580-7654-11e9-81f7-8eb6739ad8d0.png)

## Changes
- Add method `get_time_step` that defines the time step(the difference between neighbor values' timestamps)
- Method `merge_intersecting_segments` uses `time_step`
- Worker  call method  `get_time_step` before merging segments

![image](https://user-images.githubusercontent.com/39257464/57694612-d981be80-7654-11e9-84d2-9aa8d9e83572.png)
