### PR TITLE
Set ready status for span after inserting segments

### DIFF
--- a/server/src/controllers/analytics_controller.ts
+++ b/server/src/controllers/analytics_controller.ts
@@ -280,9 +280,9 @@ export async function runDetect(id: AnalyticUnit.AnalyticUnitId, from?: number, 
   let range: TimeRange;
   let intersection = 0;
 
-  const old_cache = await AnalyticUnitCache.findById(id);
-  if(old_cache !== null) {
-    intersection = old_cache.getIntersection();
+  const oldCache = await AnalyticUnitCache.findById(id);
+  if(oldCache !== null) {
+    intersection = oldCache.getIntersection();
   }
 
   try {

--- a/server/src/controllers/analytics_controller.ts
+++ b/server/src/controllers/analytics_controller.ts
@@ -317,6 +317,7 @@ export async function runDetect(id: AnalyticUnit.AnalyticUnitId, from?: number, 
 
     const payload = await processDetectionResult(id, result.payload);
     const cache = AnalyticUnitCache.AnalyticUnitCache.fromObject({ _id: id, data: payload.cache });
+    // TODO: should we use intersection from new or old cache?
     intersection = cache.getIntersection();
 
     // TODO: uncomment it

--- a/server/src/controllers/analytics_controller.ts
+++ b/server/src/controllers/analytics_controller.ts
@@ -317,8 +317,6 @@ export async function runDetect(id: AnalyticUnit.AnalyticUnitId, from?: number, 
 
     const payload = await processDetectionResult(id, result.payload);
     const cache = AnalyticUnitCache.AnalyticUnitCache.fromObject({ _id: id, data: payload.cache });
-    // TODO: should we use intersection from new or old cache?
-    intersection = cache.getIntersection();
 
     // TODO: uncomment it
     // It clears segments when redetecting on another timerange

--- a/server/src/controllers/analytics_controller.ts
+++ b/server/src/controllers/analytics_controller.ts
@@ -280,9 +280,12 @@ export async function runDetect(id: AnalyticUnit.AnalyticUnitId, from?: number, 
   let range: TimeRange;
   let intersection = 0;
 
-  const oldCache = await AnalyticUnitCache.findById(id);
+  let oldCache = await AnalyticUnitCache.findById(id);
   if(oldCache !== null) {
     intersection = oldCache.getIntersection();
+    oldCache = oldCache.data;
+  } else {
+    await AnalyticUnitCache.create(id);
   }
 
   try {
@@ -298,12 +301,6 @@ export async function runDetect(id: AnalyticUnit.AnalyticUnitId, from?: number, 
     }
     const data = await query(unit, range);
 
-    let oldCache = await AnalyticUnitCache.findById(id);
-    if(oldCache !== null) {
-      oldCache = oldCache.data;
-    } else {
-      await AnalyticUnitCache.create(id);
-    }
     let task = new AnalyticsTask(
       id,
       AnalyticsTaskType.DETECT,


### PR DESCRIPTION
fixes #644 

## Problem
Race condition when segments list is large: panel waits `READY` status and queries segments after that but database didn't save them yet.

## Changes

- set `READY` status for `DetectionSpan` **after** inserting segments. 