### PR TITLE
Remove old detected segments and detection spans when learning starts #650

### DIFF
--- a/server/src/controllers/analytics_controller.ts
+++ b/server/src/controllers/analytics_controller.ts
@@ -208,6 +208,7 @@ export async function runLearning(id: AnalyticUnit.AnalyticUnitId, from?: number
     }
     const oldSegments = await Segment.findMany(id, { labeled: false, deleted: false });
     await Segment.removeSegments(oldSegments.map(segment => segment.id));
+    await Detection.clearSpans(id);
     let oldCache = await AnalyticUnitCache.findById(id);
     if(oldCache !== null) {
       oldCache = oldCache.data;

--- a/server/src/controllers/analytics_controller.ts
+++ b/server/src/controllers/analytics_controller.ts
@@ -206,7 +206,8 @@ export async function runLearning(id: AnalyticUnit.AnalyticUnitId, from?: number
     if(analyticUnit.status === AnalyticUnit.AnalyticUnitStatus.LEARNING) {
       throw new Error('Can`t start learning when it`s already started [' + id + ']');
     }
-
+    const oldSegments = await Segment.findMany(id, { labeled: false, deleted: false });
+    await Segment.removeSegments(oldSegments.map(segment => segment.id));
     let oldCache = await AnalyticUnitCache.findById(id);
     if(oldCache !== null) {
       oldCache = oldCache.data;

--- a/server/src/controllers/analytics_controller.ts
+++ b/server/src/controllers/analytics_controller.ts
@@ -207,6 +207,7 @@ export async function runLearning(id: AnalyticUnit.AnalyticUnitId, from?: number
       throw new Error('Can`t start learning when it`s already started [' + id + ']');
     }
     const oldSegments = await Segment.findMany(id, { labeled: false, deleted: false });
+    // TODO: segments and spans are coupled. So their removing should be a transaction
     await Segment.removeSegments(oldSegments.map(segment => segment.id));
     await Detection.clearSpans(id);
     let oldCache = await AnalyticUnitCache.findById(id);


### PR DESCRIPTION
Fixes #650 

## Problem
You can get old detected segments along with new ones after re-learning (e.g. after analytic unit options change)
Same thing is actual for detection spans

## Changes
- remove previously detected segments when learning starts
- remove old spans when learning starts