### PR TITLE
AnomalyDetector: multiple segments labeling #658

### DIFF
--- a/analytics/analytics/detectors/anomaly_detector.py
+++ b/analytics/analytics/detectors/anomaly_detector.py
@@ -87,18 +87,16 @@ class AnomalyDetector(ProcessingDetector):
                 seasonality_index = seasonality // time_step
                 #TODO: upper and lower bounds for segment_data
                 segment_data = utils.exponential_smoothing(pd.Series(segment['data']), BASIC_ALPHA)
-                upper_seasonality_curve = self.add_season_to_data(
-                    smoothed_data, segment_data, seasonality_offset, seasonality_index, True
+                upper_bound = self.add_season_to_data(
+                    upper_bound, segment_data, seasonality_offset, seasonality_index, True
                 )
-                lower_seasonality_curve = self.add_season_to_data(
-                    smoothed_data, segment_data, seasonality_offset, seasonality_index, False
+                lower_bound = self.add_season_to_data(
+                    lower_bound, segment_data, seasonality_offset, seasonality_index, False
                 )
-                assert len(smoothed_data) == len(upper_seasonality_curve), \
-                    f'len smoothed {len(smoothed_data)} != len seasonality {len(upper_seasonality_curve)}'
+                assert len(smoothed_data) == len(upper_bound), \
+                    f'len smoothed {len(smoothed_data)} != len seasonality {len(upper_bound)}'
 
                 # TODO: use class for cache to avoid using string literals
-                upper_bound = upper_seasonality_curve + cache['confidence']
-                lower_bound = lower_seasonality_curve - cache['confidence']
 
         anomaly_indexes = []
         for idx, val in enumerate(data.values):
@@ -172,6 +170,8 @@ class AnomalyDetector(ProcessingDetector):
 
         # TODO: exponential_smoothing should return dataframe with related timestamps
         smoothed = utils.exponential_smoothing(dataframe['value'], cache['alpha'], cache.get('lastValue'))
+        upper_bound = smoothed + cache['confidence']
+        lower_bound = smoothed - cache['confidence']
 
         # TODO: remove duplication with detect()
         if segments is not None:

--- a/analytics/analytics/detectors/anomaly_detector.py
+++ b/analytics/analytics/detectors/anomaly_detector.py
@@ -93,7 +93,7 @@ class AnomalyDetector(ProcessingDetector):
                 lower_bound = self.add_season_to_data(
                     lower_bound, segment_data, seasonality_offset, seasonality_index, False
                 )
-                assert len(smoothed_data) == len(upper_bound), \
+                assert len(smoothed_data) == len(upper_bound) == len(lower_bound), \
                     f'len smoothed {len(smoothed_data)} != len seasonality {len(upper_bound)}'
 
                 # TODO: use class for cache to avoid using string literals
@@ -174,8 +174,7 @@ class AnomalyDetector(ProcessingDetector):
         lower_bound = smoothed - cache['confidence']
 
         # TODO: remove duplication with detect()
-        upper_bound = dataframe['value'] + cache['confidence']
-        lower_bound = dataframe['value'] - cache['confidence']
+
         if segments is not None:
             seasonality = cache.get('seasonality')
             assert seasonality is not None and seasonality > 0, \
@@ -188,19 +187,16 @@ class AnomalyDetector(ProcessingDetector):
                 seasonality_offset = (abs(segment['from'] - data_start_time) % seasonality) // time_step
                 seasonality_index = seasonality // time_step
                 segment_data = utils.exponential_smoothing(pd.Series(segment['data']), BASIC_ALPHA)
-                upper_seasonality_curve = self.add_season_to_data(
-                    smoothed, segment_data, seasonality_offset, seasonality_index, True
+                upper_bound = self.add_season_to_data(
+                    upper_bound, segment_data, seasonality_offset, seasonality_index, True
                 )
-                lower_seasonality_curve = self.add_season_to_data(
-                    smoothed, segment_data, seasonality_offset, seasonality_index, False
+                lower_bound = self.add_season_to_data(
+                    lower_bound, segment_data, seasonality_offset, seasonality_index, False
                 )
-                assert len(smoothed) == len(upper_seasonality_curve), \
-                    f'len smoothed {len(smoothed)} != len seasonality {len(upper_seasonality_curve)}'
-                smoothed = upper_seasonality_curve
+                assert len(smoothed) == len(upper_bound) == len(lower_bound), \
+                    f'len smoothed {len(smoothed)} != len seasonality {len(upper_bound)}'
 
                 # TODO: support multiple segments
-                upper_bound = upper_seasonality_curve + cache['confidence']
-                lower_bound = lower_seasonality_curve - cache['confidence']
 
         timestamps = utils.convert_series_to_timestamp_list(dataframe.timestamp)
         upper_bound_timeseries = list(zip(timestamps, upper_bound.values.tolist()))


### PR DESCRIPTION
Closes #658 
## Problem: 
When you label multiple segments in anomaly detector, every new segment delete previous seasonality from smoothed dataset.
For example for seasonity 1 day:
label first segment in 16:00 :
![image](https://user-images.githubusercontent.com/39257464/57855365-26030080-77f3-11e9-8559-14ac0266f029.png)
label second segment in 21:00 :
![image](https://user-images.githubusercontent.com/39257464/57856857-919a9d00-77f6-11e9-8eb5-c239efbd86df.png)
label both:
![image](https://user-images.githubusercontent.com/39257464/57857308-81cf8880-77f7-11e9-87ec-33282c490052.png)


## Changes:
At first, smoothed borders are determined before the loop, and then seasonality is added to it.

For example for seasonity 1 day:
label first segment in 16:00 :
![image](https://user-images.githubusercontent.com/39257464/57854446-eb986400-77f0-11e9-9d8b-6e7c7fc53e6d.png)
label second segment in 21:00 : 
![image](https://user-images.githubusercontent.com/39257464/57854580-416d0c00-77f1-11e9-829a-e0a36854b2a1.png)
label both:
![image](https://user-images.githubusercontent.com/39257464/57857163-3b7a2980-77f7-11e9-9409-c0cb32e40c6d.png)
