### PR TITLE
Anomaly detector: segments bounds #660

### DIFF
--- a/analytics/analytics/detectors/anomaly_detector.py
+++ b/analytics/analytics/detectors/anomaly_detector.py
@@ -215,11 +215,9 @@ class AnomalyDetector(ProcessingDetector):
             if (idx - offset) % seasonality == 0:
                 if addition:
                     upper_segment_bound = self.get_bounds_for_segment(segment)[0]
-                    #upper_segment_bound = upper_segment_bound - upper_segment_bound.min()
                     data = data.add(pd.Series(upper_segment_bound.values, index = segment.index + idx), fill_value = 0)
                 else:
                     lower_segment_bound = self.get_bounds_for_segment(segment)[1]
-                    #lower_segment_bound = lower_segment_bound - lower_segment_bound.min()
                     data = data.add(pd.Series(lower_segment_bound.values * -1, index = segment.index + idx), fill_value = 0)
         return data[:len_smoothed_data]
 


### PR DESCRIPTION
Closes #660 

## Problem:

Anomaly detector can't recognize change of segment nature, because upper and lower bounds are increased too much. 
![image](https://user-images.githubusercontent.com/39257464/57873808-d682fb80-7817-11e9-917b-692a0c452fd1.png)
## Change:

- add method `get_bounds_for_segment` which defines bounds for a segment so that it is located exactly between them.
- when adding seasonality, the upper and lower borders of segments are used separately

![image](https://user-images.githubusercontent.com/39257464/57874383-19919e80-7819-11e9-97c8-529d4f0c8078.png)

