### PR TITLE
TimeSeries type v2

### DIFF
--- a/analytics/analytics/analytic_types/__init__.py
+++ b/analytics/analytics/analytic_types/__init__.py
@@ -32,6 +32,8 @@ class TimeSeriesIndex(pd.DatetimeIndex):
         return pd.DatetimeIndex.__new__(cls, *args, **kwargs)
 
 # TODO: make generic type for values. See List definition for example of generic class
+# TODO: constructor from DataFrame
+# TODO: repleace TimeSeries (above) with this class: rename TimeSeries2 to TimeSeries
 class TimeSeries2(pd.Series):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/analytics/analytics/analytic_types/__init__.py
+++ b/analytics/analytics/analytic_types/__init__.py
@@ -28,9 +28,10 @@ ts = TimeSeries([4, 5, 6], tsis)
 Timestamp = Union[str, pd.Timestamp]
 
 class TimeSeriesIndex(pd.DatetimeIndex):
-    def __init__(self, timestamps: List[Timestamp]):
-        super().__init__(timestamps, dtype='datetime64[ns]')
+    def __new__(cls, *args, **kwargs):
+        return pd.DatetimeIndex.__new__(cls, *args, **kwargs)
 
-class TimeSeries(pd.Series):
-    def __init__(self, values: List[object], tsindex: TimeSeriesIndex):
-        super().__init__(values, index=tsindex)
+# TODO: make generic type for values. See List definition for example of generic class
+class TimeSeries2(pd.Series):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)

--- a/analytics/tests/test_analytic_types.py
+++ b/analytics/tests/test_analytic_types.py
@@ -1,0 +1,16 @@
+from analytic_types import TimeSeriesIndex, TimeSeries2
+
+import unittest
+
+
+class TestDataset(unittest.TestCase):
+    def test_basic_timeseries_index(self):
+        tsi = TimeSeriesIndex(['2017-12-31 16:00:00-08:00'])
+        self.assertEqual(len(tsi), 1)
+        tsi2 = TimeSeriesIndex(['2017-12-31 16:00:00-08:00', '2017-12-31 17:00:00-08:00', '2017-12-31 18:00:00-08:00'])
+        self.assertEqual(len(tsi2), 3)
+
+    def test_basic_timeseries(self):
+        tsis = TimeSeriesIndex(['2017-12-31 16:00:00-08:00', '2017-12-31 17:00:00-08:00', '2017-12-31 18:00:00-08:00'])
+        ts = TimeSeries2([4, 5, 6], tsis)
+        self.assertEqual(len(ts), 3)


### PR DESCRIPTION
We don't use `analytic_types.TimeSeriesIndex` and `analytic_types.TimeSeries` classes. This PR improves implementation of this classes to get closer to something usable

## Changes
* `TimeSeries` -> `TimeSeries2` renaming (it's because we have alias `TimeSeries = List[Tuple[int, float]]`)
* Better inheritance of `TimeSeriesIndex` from `pd.DatetimeIndex` -- there were a problem with `__new__`
* Basic inheritance of `TimeSeries2` from `pd.Series` 
* Basic tests for `TimeSeriesIndex` and `TimeSeries2`

## Other

In next iteration I would 
* set the exact datatype for `TimeSeriesIndex` like `dtype='datetime64[ns]'`, please guide
* construction from `DataFrame`

### See also 
* https://stackoverflow.com/questions/10788976/how-do-i-properly-inherit-from-a-superclass-that-has-a-new-method