### PR TITLE
AnomalyDetector: Need at least 1 labeled segment #667

### DIFF
--- a/server/src/controllers/analytics_controller.ts
+++ b/server/src/controllers/analytics_controller.ts
@@ -152,6 +152,7 @@ async function getQueryRange(
     default:
       throw new Error(`Cannot get query range for detector type ${detectorType}`);
   }
+}
 
 async function query(
   analyticUnit: AnalyticUnit.AnalyticUnit,

--- a/server/src/controllers/analytics_controller.ts
+++ b/server/src/controllers/analytics_controller.ts
@@ -121,8 +121,7 @@ async function getQueryRange(
   detectorType: AnalyticUnit.DetectorType
 ): Promise<TimeRange> {
   if(
-    detectorType === AnalyticUnit.DetectorType.PATTERN ||
-    detectorType === AnalyticUnit.DetectorType.ANOMALY
+    detectorType === AnalyticUnit.DetectorType.PATTERN
   ) {
     const segments = await Segment.findMany(analyticUnitId, { $or: { labeled: true, deleted: true } });
     if(segments.length === 0) {
@@ -138,6 +137,20 @@ async function getQueryRange(
       from: now - 5 * SECONDS_IN_MINUTE * 1000,
       to: now
     };
+  }
+
+  if (detectorType === AnalyticUnit.DetectorType.ANOMALY) {
+    const segments = await Segment.findMany(analyticUnitId, { $or: { labeled: true, deleted: true } });
+    if (segments.length === 0) {
+      const now = Date.now();
+      return {
+        from: now - 5 * SECONDS_IN_MINUTE * 1000,
+        to: now
+      };
+    }
+    else {
+      return getQueryRangeForLearningBySegments(segments);
+    }
   }
 
   throw new Error(`Cannot get query range for detector type ${detectorType}`);


### PR DESCRIPTION
Closes #667 

## Problem:

When you click `re-detect all analytic units` in panel, you get "Need at least 1 labeled segment" error for anomaly analytic units without seasonality. Although they don't need segments for learning.

## Change:

Add separate condition for anomaly detector in `getQueryRange`. 
If analytic unit has segments - method uses pattern detector logic,
if there are no segments - method uses threshold detector logic.