### PR TITLE
Anomaly detector:  last NaN value #677

### DIFF
--- a/analytics/analytics/utils/common.py
+++ b/analytics/analytics/utils/common.py
@@ -32,8 +32,10 @@ def exponential_smoothing(series: pd.Series, alpha: float, last_smoothed_value: 
         result = [0]
     for n in range(1, len(series)):
         if np.isnan(series[n]):
-            series[n] = 0
-        result.append(alpha * series[n] + (1 - alpha) * result[n - 1])
+            result.append((1 - alpha) * result[n - 1])
+            series.values[n] = result[n]
+        else:
+            result.append(alpha * series[n] + (1 - alpha) * result[n - 1])
     return pd.Series(result, index = series.index)
 
 def find_pattern(data: pd.Series, height: float, length: int, pattern_type: str) -> list:


### PR DESCRIPTION
Closes #677 

## Problem

Anomalies are detected where they should not be.
Example:
![anomaly](https://user-images.githubusercontent.com/39257464/58708393-57b5c300-83c0-11e9-87e3-cff9cff59836.jpg)

It happens because last value in dataset is almost always NaN

## Changes

- `exponential_smoothing()`: change NaN to smoothed value
