### PR TITLE
Error: Cannot read property 'alpha' of null

### DIFF
--- a/server/src/routes/data_router.ts
+++ b/server/src/routes/data_router.ts
@@ -39,7 +39,7 @@ async function query(ctx: Router.IRouterContext) {
 
   const analyticUnit = await AnalyticUnit.findById(analyticUnitId);
 
-  if(analyticUnit === undefined) {
+  if(analyticUnit === null) {
     throw new Error(`can't find analytic unit ${analyticUnitId}`);
   }
 


### PR DESCRIPTION
fixes #686 

## Changes

- check for null instead of undefined