### PR TITLE
Anomaly detector bounds switch disabling to enabling #709

### DIFF
--- a/analytics/.vscode/settings.json
+++ b/analytics/.vscode/settings.json
@@ -14,7 +14,7 @@
   "python.pythonPath": "python",
   "python.linting.enabled": true,
   "python.testing.unittestArgs": [ "-v" ],
-  "python.testing.pyTestEnabled": false,
+  "python.testing.pytestEnabled": false,
   "python.testing.nosetestsEnabled": false,
   "python.testing.unittestEnabled": true,
   "python.linting.pylintEnabled": true,

--- a/analytics/analytics/detectors/anomaly_detector.py
+++ b/analytics/analytics/detectors/anomaly_detector.py
@@ -79,8 +79,12 @@ class AnomalyDetector(ProcessingDetector):
         bounds[Bound.LOWER.value] = ( smoothed_data - cache['confidence'], operator.lt )
         bounds[Bound.UPPER.value] = ( smoothed_data + cache['confidence'], operator.gt )
 
-        if enable_bounds != Bound.ALL.value:
-            del bounds[enable_bounds]
+        if enable_bounds == Bound.LOWER.value:
+            del bounds[Bound.UPPER.value]
+
+        if enable_bounds == Bound.UPPER.value:
+            del bounds[Bound.LOWER.value]
+
 
         if segments is not None:
 
@@ -184,8 +188,11 @@ class AnomalyDetector(ProcessingDetector):
         bounds[Bound.LOWER.value] = smoothed_data - cache['confidence']
         bounds[Bound.UPPER.value] = smoothed_data + cache['confidence']
 
-        if enable_bounds != Bound.ALL.value:
-            del bounds[enable_bounds]
+        if enable_bounds == Bound.LOWER.value:
+            del bounds[Bound.UPPER.value]
+
+        if enable_bounds == Bound.UPPER.value:
+            del bounds[Bound.LOWER.value]
 
 
         # TODO: remove duplication with detect()

--- a/server/src/controllers/analytics_controller.ts
+++ b/server/src/controllers/analytics_controller.ts
@@ -287,7 +287,7 @@ export async function runLearning(id: AnalyticUnit.AnalyticUnitId, from?: number
         taskPayload.anomaly = {
           alpha: (analyticUnit as AnomalyAnalyticUnit).alpha,
           confidence: (analyticUnit as AnomalyAnalyticUnit).confidence,
-          disableBound: (analyticUnit as AnomalyAnalyticUnit).disableBound
+          enableBounds: (analyticUnit as AnomalyAnalyticUnit).enableBounds
         };
 
         taskPayload.data = await getPayloadData(analyticUnit, from, to);

--- a/server/src/models/analytic_units/anomaly_analytic_unit_model.ts
+++ b/server/src/models/analytic_units/anomaly_analytic_unit_model.ts
@@ -9,7 +9,7 @@ type SeasonalityPeriod = {
 }
 
 enum Bound {
-  NONE = 'NONE',
+  ALL = 'ALL',
   UPPER = 'UPPER',
   LOWER = 'LOWER'
 };
@@ -26,7 +26,7 @@ export class AnomalyAnalyticUnit extends AnalyticUnit {
     public confidence: number,
     public seasonality: number, //seasonality in ms
     private seasonalityPeriod: SeasonalityPeriod,
-    public disableBound: Bound,
+    public enableBounds: Bound,
     metric?: Metric,
     alert?: boolean,
     id?: AnalyticUnitId,
@@ -65,7 +65,7 @@ export class AnomalyAnalyticUnit extends AnalyticUnit {
       confidence: this.confidence,
       seasonality: this.seasonality,
       seasonalityPeriod: this.seasonalityPeriod,
-      disableBound: this.disableBound
+      disableBound: this.enableBounds
     };
   }
 
@@ -77,7 +77,7 @@ export class AnomalyAnalyticUnit extends AnalyticUnit {
       confidence: this.confidence,
       seasonality: this.seasonality,
       seasonalityPeriod: this.seasonalityPeriod,
-      disableBound: this.disableBound
+      disableBound: this.enableBounds
     };
   }
 

--- a/server/src/models/analytic_units/anomaly_analytic_unit_model.ts
+++ b/server/src/models/analytic_units/anomaly_analytic_unit_model.ts
@@ -65,7 +65,7 @@ export class AnomalyAnalyticUnit extends AnalyticUnit {
       confidence: this.confidence,
       seasonality: this.seasonality,
       seasonalityPeriod: this.seasonalityPeriod,
-      disableBound: this.enableBounds
+      enableBounds: this.enableBounds
     };
   }
 
@@ -77,7 +77,7 @@ export class AnomalyAnalyticUnit extends AnalyticUnit {
       confidence: this.confidence,
       seasonality: this.seasonality,
       seasonalityPeriod: this.seasonalityPeriod,
-      disableBound: this.enableBounds
+      enableBounds: this.enableBounds
     };
   }
 
@@ -97,7 +97,7 @@ export class AnomalyAnalyticUnit extends AnalyticUnit {
       obj.confidence,
       obj.seasonality,
       obj.seasonalityPeriod,
-      obj.disableBound,
+      obj.enableBounds,
       metric,
       obj.alert,
       obj._id,


### PR DESCRIPTION
fixes #709 

### Changes
- invert logic of detections and processing
- added migration to 5 revision (disableBounds -> enabledBounds)

### Notes
For structuring of `payload` and resolving following TODO in anomaly_detector's detect method:
```
# TODO: use class for cache to avoid using string literals and Bound.TYPE.value
```
there is issue https://github.com/hastic/hastic-server/issues/678