### PR TITLE
Slack webhook returns 400 missing_text_or_fallback_or_attachments #708

### DIFF
--- a/server/src/services/alert_service.ts
+++ b/server/src/services/alert_service.ts
@@ -1,4 +1,4 @@
-import { sendNotification, MetaInfo, MetaAnalytic, WebhookType, Notification } from './notification_service';
+import { sendNotification, MetaInfo, AnalyticMeta, WebhookType, Notification } from './notification_service';
 import * as AnalyticUnit from '../models/analytic_units';
 import { Segment } from '../models/segment_model';
 import { availableReporter } from '../utils/reporter';
@@ -57,12 +57,12 @@ export class Alert {
     return new Buffer(response.data, 'binary').toString('base64');
   }
 
-  protected makeMeta(segment: Segment): MetaAnalytic {
+  protected makeMeta(segment: Segment): AnalyticMeta {
     const dashdoardId = this.analyticUnit.panelId.split('/')[0];
     const panelId = this.analyticUnit.panelId.split('/')[1];
     const grafanaUrl = `${this.analyticUnit.grafanaUrl}/d/${dashdoardId}?panelId=${panelId}&edit=true&fullscreen=true?orgId=${ORG_ID}`;
 
-    let alert: MetaAnalytic = {
+    let alert: AnalyticMeta = {
       type: WebhookType.DETECT,
       analyticUnitType: this.analyticUnit.type,
       analyticUnitName: this.analyticUnit.name,
@@ -76,7 +76,7 @@ export class Alert {
     return alert;
   }
 
-  protected makeMessage(meta: MetaAnalytic): string {
+  protected makeMessage(meta: AnalyticMeta): string {
     return [
     `[${meta.analyticUnitType.toUpperCase()} ALERTING] ${meta.analyticUnitName}`,
     `URL: ${meta.grafanaUrl}`,
@@ -102,7 +102,7 @@ class PatternAlert extends Alert {
     }
   }
 
-  protected makeMessage(meta: MetaAnalytic): string {
+  protected makeMessage(meta: AnalyticMeta): string {
     return [
       `[PATTERN DETECTED] ${meta.analyticUnitName}`,
       `URL: ${meta.grafanaUrl}`,
@@ -140,7 +140,7 @@ class ThresholdAlert extends Alert {
     }
   }
 
-  protected makeMessage(meta: MetaAnalytic): string {
+  protected makeMessage(meta: AnalyticMeta): string {
     let message = [
       `[THRESHOLD ALERTING] ${meta.analyticUnitName}`,
       `URL: ${meta.grafanaUrl}`,

--- a/server/src/services/alert_service.ts
+++ b/server/src/services/alert_service.ts
@@ -24,8 +24,8 @@ export class Alert {
 
   protected async makeNotification(segment: Segment): Promise<Notification> {
     const meta = this.makeMeta(segment);
-    const message = this.makeMessage(meta);
-    let result: Notification = { meta, message };
+    const text = this.makeMessage(meta);
+    let result: Notification = { meta, text };
     if(HASTIC_WEBHOOK_IMAGE_ENABLED) {
       try {
        const image = await this.loadImage();
@@ -187,7 +187,7 @@ export class AlertService {
     this._alerts[id].receive(segment);
   };
 
-  public sendMsg(message: string, type: WebhookType, optionalInfo = {}) {
+  public sendMsg(text: string, type: WebhookType, optionalInfo = {}) {
     const now = Date.now();
     const infoAlert: InfoMeta = {
       params: optionalInfo,
@@ -195,7 +195,7 @@ export class AlertService {
       from: now,
       to: now
     }
-    sendNotification({ message, meta: infoAlert });
+    sendNotification({ text, meta: infoAlert });
   }
 
   public sendGrafanaAvailableWebhook() {

--- a/server/src/services/analytics_service.ts
+++ b/server/src/services/analytics_service.ts
@@ -182,14 +182,14 @@ export class AnalyticsService {
       this.sendTask(this._queue.shift(), true);
     }
     console.log(msg);
-    this._alertService.sendMsg(msg, WebhookType.RECOVERY);
+    this._alertService.sendMessage(msg, WebhookType.RECOVERY);
   }
 
   private async _onAnalyticsDown() {
     const msg = 'Analytics is down';
     console.log(msg);
     // TODO: enable analytics down webhooks when it stops bouncing
-    this._alertService.sendMsg(msg, WebhookType.FAILURE);
+    this._alertService.sendMessage(msg, WebhookType.FAILURE);
     if(this._productionMode && !this._inDocker) {
       await AnalyticsService._runAnalyticsProcess(this._zmqConnectionString);
     }

--- a/server/src/services/analytics_service.ts
+++ b/server/src/services/analytics_service.ts
@@ -188,7 +188,6 @@ export class AnalyticsService {
   private async _onAnalyticsDown() {
     const msg = 'Analytics is down';
     console.log(msg);
-    // TODO: enable analytics down webhooks when it stops bouncing
     this._alertService.sendMessage(msg, WebhookType.FAILURE);
     if(this._productionMode && !this._inDocker) {
       await AnalyticsService._runAnalyticsProcess(this._zmqConnectionString);

--- a/server/src/services/notification_service.ts
+++ b/server/src/services/notification_service.ts
@@ -17,7 +17,7 @@ export enum WebhookType {
   MESSAGE = 'MESSAGE'
 }
 
-export declare type AnalyticMeta = {
+export declare type MetaAnalytic = {
   type: WebhookType,
   analyticUnitType: string,
   analyticUnitName: string,
@@ -28,7 +28,7 @@ export declare type AnalyticMeta = {
   message?: any
 }
 
-export declare type InfoMeta = {
+export declare type MetaInfo = {
   type: WebhookType,
   from: number,
   to: number,
@@ -37,7 +37,7 @@ export declare type InfoMeta = {
 
 export declare type Notification = {
   text: string,
-  meta: InfoMeta | AnalyticMeta,
+  meta: MetaInfo | MetaAnalytic,
   image?: any
 }
 

--- a/server/src/services/notification_service.ts
+++ b/server/src/services/notification_service.ts
@@ -43,7 +43,7 @@ export declare type Notification = {
 
 export async function sendNotification(notification: Notification) {
   if(HASTIC_WEBHOOK_URL === null) {
-    console.log(`HASTIC_WEBHOOK_URL is not set, skip sending notification: ${notification.message}`);
+    console.log(`HASTIC_WEBHOOK_URL is not set, skip sending notification: ${notification.text}`);
     return;
   }
 

--- a/server/src/services/notification_service.ts
+++ b/server/src/services/notification_service.ts
@@ -36,7 +36,7 @@ export declare type InfoMeta = {
 }
 
 export declare type Notification = {
-  message: string,
+  text: string,
   meta: InfoMeta | AnalyticMeta,
   image?: any
 }
@@ -46,7 +46,7 @@ export async function sendNotification(notification: Notification) {
     throw new Error(`Can't send notification, HASTIC_WEBHOOK_URL is undefined`);
   }
 
-  notification.message += `\nInstance: ${HASTIC_INSTANCE_NAME}`;
+  notification.text += `\nInstance: ${HASTIC_INSTANCE_NAME}`;
 
   let data;
   if(HASTIC_WEBHOOK_TYPE === ContentType.JSON) {

--- a/server/src/services/notification_service.ts
+++ b/server/src/services/notification_service.ts
@@ -17,7 +17,7 @@ export enum WebhookType {
   MESSAGE = 'MESSAGE'
 }
 
-export declare type MetaAnalytic = {
+export declare type AnalyticMeta = {
   type: WebhookType,
   analyticUnitType: string,
   analyticUnitName: string,
@@ -37,7 +37,7 @@ export declare type MetaInfo = {
 
 export declare type Notification = {
   text: string,
-  meta: MetaInfo | MetaAnalytic,
+  meta: MetaInfo | AnalyticMeta,
   image?: any
 }
 


### PR DESCRIPTION
fix #708 

related hastic-telegram-bot PR: https://github.com/hastic/hastic-telegram-bot/pull/2

### Changes
- just rename `message` to `text`