### PR TITLE
Error: too many values to unpack #721

### DIFF
--- a/analytics/analytics/analytic_unit_manager.py
+++ b/analytics/analytics/analytic_unit_manager.py
@@ -17,7 +17,7 @@ def get_detector_by_type(
     if detector_type == 'pattern':
         return detectors.PatternDetector(analytic_unit_type, analytic_unit_id)
     elif detector_type == 'threshold':
-        return detectors.ThresholdDetector()
+        return detectors.ThresholdDetector(analytic_unit_id)
     elif detector_type == 'anomaly':
         return detectors.AnomalyDetector(analytic_unit_id)
 

--- a/analytics/analytics/detectors/anomaly_detector.py
+++ b/analytics/analytics/detectors/anomaly_detector.py
@@ -1,7 +1,6 @@
 from enum import Enum
 import logging
 import numpy as np
-from collections import OrderedDict
 import pandas as pd
 import math
 from typing import Optional, Union, List, Tuple

--- a/analytics/analytics/detectors/detector.py
+++ b/analytics/analytics/detectors/detector.py
@@ -45,7 +45,7 @@ class Detector(ABC):
     def get_value_from_cache(self, cache: ModelCache, key: str, required = False):
         value = cache.get(key)
         if value == None and required:
-            raise f'Missing required "{key}" field in cache for analytic unit {self.analytic_unit_id}'
+            raise ValueError(f'Missing required "{key}" field in cache for analytic unit {self.analytic_unit_id}')
         return value
 
 

--- a/analytics/analytics/detectors/detector.py
+++ b/analytics/analytics/detectors/detector.py
@@ -2,12 +2,15 @@ from abc import ABC, abstractmethod
 from pandas import DataFrame
 from typing import Optional, Union, List
 
-from analytic_types import ModelCache, TimeSeries
+from analytic_types import ModelCache, TimeSeries, AnalyticUnitId
 from analytic_types.detector_typing import DetectionResult, ProcessingResult
 from analytic_types.segment import Segment
 
 
 class Detector(ABC):
+
+    def __init__(self, analytic_unit_id: AnalyticUnitId):
+        self.analytic_unit_id = analytic_unit_id
 
     @abstractmethod
     def train(self, dataframe: DataFrame, payload: Union[list, dict], cache: Optional[ModelCache]) -> ModelCache:
@@ -38,6 +41,12 @@ class Detector(ABC):
             result.last_detection_time = detection.last_detection_time
             result.cache = detection.cache
         return result
+
+    def get_value_from_cache(self, cache: ModelCache, key: str, required = False):
+        value = cache.get(key)
+        if value == None and required:
+            raise f'Missing required "{key}" field in cache for analytic unit {self.analytic_unit_id}'
+        return value
 
 
 class ProcessingDetector(Detector):

--- a/analytics/analytics/detectors/pattern_detector.py
+++ b/analytics/analytics/detectors/pattern_detector.py
@@ -41,7 +41,7 @@ class PatternDetector(Detector):
     DEFAULT_WINDOW_SIZE = 1
 
     def __init__(self, pattern_type: str, analytic_unit_id: AnalyticUnitId):
-        self.analytic_unit_id = analytic_unit_id
+        super().__init__(analytic_unit_id)
         self.pattern_type = pattern_type
         self.model = resolve_model_by_pattern(self.pattern_type)
         self.bucket = DataBucket()

--- a/analytics/analytics/detectors/threshold_detector.py
+++ b/analytics/analytics/detectors/threshold_detector.py
@@ -5,7 +5,7 @@ import pandas as pd
 import numpy as np
 from typing import Optional, List
 
-from analytic_types import ModelCache
+from analytic_types import ModelCache, AnalyticUnitId
 from analytic_types.detector_typing import DetectionResult
 from analytic_types.segment import Segment
 from detectors import Detector
@@ -20,8 +20,8 @@ class ThresholdDetector(Detector):
 
     WINDOW_SIZE = 3
 
-    def __init__(self):
-        pass
+    def __init__(self, analytic_unit_id: AnalyticUnitId):
+        super().__init__(analytic_unit_id)
 
     def train(self, dataframe: pd.DataFrame, threshold: dict, cache: Optional[ModelCache]) -> ModelCache:
         time_step = utils.find_interval(dataframe)

--- a/analytics/analytics/utils/common.py
+++ b/analytics/analytics/utils/common.py
@@ -36,6 +36,9 @@ def exponential_smoothing(series: pd.Series, alpha: float, last_smoothed_value: 
             series.values[n] = result[n]
         else:
             result.append(alpha * series[n] + (1 - alpha) * result[n - 1])
+    
+    assert len(result) == len(series), \
+        f'len of smoothed data {len(result)} != len of original dataset {len(series)}'
     return pd.Series(result, index = series.index)
 
 def find_pattern(data: pd.Series, height: float, length: int, pattern_type: str) -> list:

--- a/analytics/tests/test_detectors.py
+++ b/analytics/tests/test_detectors.py
@@ -22,7 +22,7 @@ class TestThresholdDetector(unittest.TestCase):
 
     def test_invalid_cache(self):
 
-        detector = threshold_detector.ThresholdDetector()
+        detector = threshold_detector.ThresholdDetector('test_id')
         
         with self.assertRaises(ValueError):
             detector.detect([], None)

--- a/analytics/tests/test_detectors.py
+++ b/analytics/tests/test_detectors.py
@@ -2,7 +2,7 @@ import unittest
 import pandas as pd
 
 from detectors import pattern_detector, threshold_detector, anomaly_detector
-from analytic_types.detector_typing import DetectionResult
+from analytic_types.detector_typing import DetectionResult, ProcessingResult
 
 class TestPatternDetector(unittest.TestCase):
 
@@ -10,10 +10,9 @@ class TestPatternDetector(unittest.TestCase):
 
         data = [[0,1], [1,2]]
         dataframe = pd.DataFrame(data, columns=['timestamp', 'values'])
-        cache = {'windowSize': 10}
+        cache = { 'windowSize': 10 }
 
         detector = pattern_detector.PatternDetector('GENERAL', 'test_id')
-        
         with self.assertRaises(ValueError):
             detector.detect(dataframe, cache)
 
@@ -23,7 +22,7 @@ class TestThresholdDetector(unittest.TestCase):
     def test_invalid_cache(self):
 
         detector = threshold_detector.ThresholdDetector('test_id')
-        
+
         with self.assertRaises(ValueError):
             detector.detect([], None)
 
@@ -33,7 +32,7 @@ class TestThresholdDetector(unittest.TestCase):
 
 class TestAnomalyDetector(unittest.TestCase):
 
-    def test_dataframe(self):
+    def test_detect(self):
         data_val = [0, 1, 2, 1, 2, 10, 1, 2, 1]
         data_ind = [1523889000000 + i for i in range(len(data_val))]
         data = {'timestamp': data_ind, 'value': data_val}
@@ -45,8 +44,91 @@ class TestAnomalyDetector(unittest.TestCase):
             'timeStep': 1
         }
         detector = anomaly_detector.AnomalyDetector('test_id')
-        detect_result: DetectionResult = detector.detect(dataframe, cache)
 
+        detect_result: DetectionResult = detector.detect(dataframe, cache)
         detected_segments = list(map(lambda s: {'from': s.from_timestamp, 'to': s.to_timestamp}, detect_result.segments))
         result = [{ 'from': 1523889000005.0, 'to': 1523889000005.0 }]
         self.assertEqual(result, detected_segments)
+
+        cache =  {
+            'confidence': 2,
+            'alpha': 0.1,
+            'timeStep': 1,
+            'seasonality': 4,
+            'segments': [{ 'from': 1523889000001, 'to': 1523889000002, 'data': [10] }]
+        }
+        detect_result: DetectionResult = detector.detect(dataframe, cache)
+        detected_segments = list(map(lambda s: {'from': s.from_timestamp, 'to': s.to_timestamp}, detect_result.segments))
+        result = []
+        self.assertEqual(result, detected_segments)
+
+    def test_process_data(self):
+        data_val = [0, 1, 2, 1, 2, 10, 1, 2, 1]
+        data_ind = [1523889000000 + i for i in range(len(data_val))]
+        data = {'timestamp': data_ind, 'value': data_val}
+        dataframe = pd.DataFrame(data = data)
+        dataframe['timestamp'] = pd.to_datetime(dataframe['timestamp'], unit='ms')
+        cache =  {
+            'confidence': 2,
+            'alpha': 0.1,
+            'timeStep': 1
+        }
+        detector = anomaly_detector.AnomalyDetector('test_id')
+        detect_result: ProcessingResult = detector.process_data(dataframe, cache)
+        expected_result = {
+            'lowerBound': [
+                (1523889000000, -2.0),
+                (1523889000001, -1.9),
+                (1523889000002, -1.71),
+                (1523889000003, -1.6389999999999998),
+                (1523889000004, -1.4750999999999999),
+                (1523889000005, -0.5275899999999998),
+                (1523889000006, -0.5748309999999996),
+                (1523889000007, -0.5173478999999996),
+                (1523889000008, -0.5656131099999995)
+            ],
+            'upperBound': [
+                (1523889000000, 2.0),
+                (1523889000001, 2.1),
+                (1523889000002, 2.29),
+                (1523889000003, 2.361),
+                (1523889000004, 2.5249),
+                (1523889000005, 3.47241),
+                (1523889000006, 3.4251690000000004),
+                (1523889000007, 3.4826521),
+                (1523889000008, 3.4343868900000007)
+            ]}
+        self.assertEqual(detect_result.to_json(), expected_result)
+
+        cache =  {
+            'confidence': 2,
+            'alpha': 0.1,
+            'timeStep': 1,
+            'seasonality': 5,
+            'segments': [{ 'from': 1523889000001, 'to': 1523889000002, 'data': [1] }]
+        }
+        detect_result: ProcessingResult = detector.process_data(dataframe, cache)
+        expected_result = {
+            'lowerBound': [
+                (1523889000000, -2.0),
+                (1523889000001, -2.9),
+                (1523889000002, -1.71),
+                (1523889000003, -1.6389999999999998),
+                (1523889000004, -1.4750999999999999),
+                (1523889000005, -0.5275899999999998),
+                (1523889000006, -1.5748309999999996),
+                (1523889000007, -0.5173478999999996),
+                (1523889000008, -0.5656131099999995)
+            ],
+            'upperBound': [
+                (1523889000000, 2.0),
+                (1523889000001, 3.1),
+                (1523889000002, 2.29),
+                (1523889000003, 2.361),
+                (1523889000004, 2.5249),
+                (1523889000005, 3.47241),
+                (1523889000006, 4.425169),
+                (1523889000007, 3.4826521),
+                (1523889000008, 3.4343868900000007)
+            ]}
+        self.assertEqual(detect_result.to_json(), expected_result)


### PR DESCRIPTION
Fixes #721 

Error happens in anomaly detector when seasonality is used.  The reason is bounds refactoring in the https://github.com/hastic/hastic-server/pull/703 PR (anomaly bound data became a tuple instead of list). 
This tuple has been handled correctly for the case of detection with seasonality. Although, it was still handled as list for the case of detection without seasonality.

## Changes
- refactor work with bounds
- raise if there are no required fields in cache
- test both seasonality / without seasonality cases for `detect()` and `process_data()`