### PR TITLE
WIP: Missing piece of HSR in the end #731

### DIFF
--- a/server/src/controllers/analytics_controller.ts
+++ b/server/src/controllers/analytics_controller.ts
@@ -629,9 +629,14 @@ export async function getHSR(
   upperBound?: TableTimeSeries
 }> {
   try {
+    //TODO: Use aggregation time instead of 2nd query when it's supported by grafana-datasource-kit
+    let timestep = 86400000;
     const grafanaUrl = getGrafanaUrl(analyticUnit.grafanaUrl);
-    const data = await queryByMetric(analyticUnit.metric, grafanaUrl, from, to, HASTIC_API_KEY);
-
+    let data = await queryByMetric(analyticUnit.metric, grafanaUrl, from, to, HASTIC_API_KEY);
+    if (data.values != undefined && data.values.length > 1) {
+      timestep = data.values[1][0] - data.values[0][0];
+    }
+    data = await queryByMetric(analyticUnit.metric, grafanaUrl, from, to + timestep, HASTIC_API_KEY);
     if(analyticUnit.detectorType !== AnalyticUnit.DetectorType.ANOMALY) {
       return { hsr: data };
     }

--- a/server/src/controllers/analytics_controller.ts
+++ b/server/src/controllers/analytics_controller.ts
@@ -630,7 +630,7 @@ export async function getHSR(
 }> {
   try {
     //TODO: Use aggregation time instead of 2nd query when it's supported by grafana-datasource-kit
-    let timestep = 86400000;
+    let timestep = 0;
     const grafanaUrl = getGrafanaUrl(analyticUnit.grafanaUrl);
     let data = await queryByMetric(analyticUnit.metric, grafanaUrl, from, to, HASTIC_API_KEY);
     if (data.values != undefined && data.values.length > 1) {

--- a/server/src/controllers/analytics_controller.ts
+++ b/server/src/controllers/analytics_controller.ts
@@ -635,8 +635,8 @@ export async function getHSR(
     let data = await queryByMetric(analyticUnit.metric, grafanaUrl, from, to, HASTIC_API_KEY);
     if (data.values != undefined && data.values.length > 1) {
       timestep = data.values[1][0] - data.values[0][0];
+      data = await queryByMetric(analyticUnit.metric, grafanaUrl, from, to + timestep, HASTIC_API_KEY);
     }
-    data = await queryByMetric(analyticUnit.metric, grafanaUrl, from, to + timestep, HASTIC_API_KEY);
     if(analyticUnit.detectorType !== AnalyticUnit.DetectorType.ANOMALY) {
       return { hsr: data };
     }


### PR DESCRIPTION
HSR  is cut in the end of the chart.

Will be fixed after #733 

## Changes
- Add `timestep` (difference between first 2 dataset timestamps)
- Add second HSR query for `[to; to + timestep]` range

## PATTERN BEFORE:
![image](https://user-images.githubusercontent.com/39257464/61938056-e1d17080-af98-11e9-94e1-b7f41182849e.png)
## PATTERN AFTER:
![image](https://user-images.githubusercontent.com/39257464/61938118-00376c00-af99-11e9-9e5d-7ae52ab1a8c6.png)

## ANOMALY BEFORE:
![image](https://user-images.githubusercontent.com/39257464/61938403-a97e6200-af99-11e9-9785-7204977e2585.png)
## ANOMALY AFTER:
![image](https://user-images.githubusercontent.com/39257464/61938446-c6b33080-af99-11e9-8342-41a10ea52fdf.png)
