### PR TITLE
Error cannot read property data of null #739

### DIFF
--- a/server/src/controllers/analytics_controller.ts
+++ b/server/src/controllers/analytics_controller.ts
@@ -3,6 +3,7 @@ import { AnalyticsTask, AnalyticsTaskType, AnalyticsTaskId } from '../models/ana
 import * as AnalyticUnitCache from '../models/analytic_unit_cache_model';
 import * as Segment from '../models/segment_model';
 import * as AnalyticUnit from '../models/analytic_units';
+import { ThresholdAnalyticUnit, AnomalyAnalyticUnit} from '../models/analytic_units';
 import * as Detection from '../models/detection_model';
 import { AnalyticsService } from '../services/analytics_service';
 import { AlertService } from '../services/alert_service';
@@ -271,21 +272,21 @@ export async function runLearning(id: AnalyticUnit.AnalyticUnitId, from?: number
         break;
       case AnalyticUnit.DetectorType.THRESHOLD:
         taskPayload.threshold = {
-          value: (analyticUnit as AnalyticUnit.ThresholdAnalyticUnit).value,
-          condition: (analyticUnit as AnalyticUnit.ThresholdAnalyticUnit).condition
+          value: (analyticUnit as ThresholdAnalyticUnit).value,
+          condition: (analyticUnit as ThresholdAnalyticUnit).condition
         };
         taskPayload.data = await getPayloadData(analyticUnit, from, to);
         break;
       case AnalyticUnit.DetectorType.ANOMALY:
         taskPayload.anomaly = {
-          alpha: (analyticUnit as AnalyticUnit.AnomalyAnalyticUnit).alpha,
-          confidence: (analyticUnit as AnalyticUnit.AnomalyAnalyticUnit).confidence,
-          enableBounds: (analyticUnit as AnalyticUnit.AnomalyAnalyticUnit).enableBounds
+          alpha: (analyticUnit as AnomalyAnalyticUnit).alpha,
+          confidence: (analyticUnit as AnomalyAnalyticUnit).confidence,
+          enableBounds: (analyticUnit as AnomalyAnalyticUnit).enableBounds
         };
 
         taskPayload.data = await getPayloadData(analyticUnit, from, to);
 
-        const seasonality = (analyticUnit as AnalyticUnit.AnomalyAnalyticUnit).seasonality;
+        const seasonality = (analyticUnit as AnomalyAnalyticUnit).seasonality;
         if(seasonality > 0) {
           let segments = await Segment.findMany(id, { deleted: true });
           if(segments.length === 0) {

--- a/server/src/controllers/analytics_controller.ts
+++ b/server/src/controllers/analytics_controller.ts
@@ -658,8 +658,7 @@ export async function getHSR(
     }
 
     let cache = await AnalyticUnitCache.findById(analyticUnit.id);
-    const analyticFields = analyticUnit.getAnalyticFields();
-    if(cache === null || !_.every(_.keys(analyticFields).map(k => analyticFields[k] === cache.data[k]))) {
+    if(cache === null || !_.every(_.keys(analyticUnit.analyticProps).map(k => _.isEqual(analyticUnit.analyticProps[k], cache.data[k])))) {
       await runLearning(analyticUnit.id, from, to);
       cache = await AnalyticUnitCache.findById(analyticUnit.id);
     }

--- a/server/src/controllers/analytics_controller.ts
+++ b/server/src/controllers/analytics_controller.ts
@@ -658,7 +658,7 @@ export async function getHSR(
     }
 
     let cache = await AnalyticUnitCache.findById(analyticUnit.id);
-    if(cache === null || !_.every(_.keys(analyticUnit.analyticProps).map(k => _.isEqual(analyticUnit.analyticProps[k], cache.data[k])))) {
+    if(cache === null || analyticCacheOutdated(analyticUnit, cache)) {
       await runLearning(analyticUnit.id, from, to);
       cache = await AnalyticUnitCache.findById(analyticUnit.id);
     }
@@ -694,4 +694,10 @@ export async function getHSR(
     await AnalyticUnit.setStatus(analyticUnit.id, AnalyticUnit.AnalyticUnitStatus.FAILED, message);
     throw new Error(message);
   }
+}
+
+function analyticCacheOutdated(analyticUnit: AnalyticUnit.AnalyticUnit, cache: AnalyticUnitCache.AnalyticUnitCache) {
+  return !_.every(
+    _.keys(analyticUnit.analyticProps).map(k => _.isEqual(analyticUnit.analyticProps[k], cache.data[k]))
+  );
 }

--- a/server/src/controllers/analytics_controller.ts
+++ b/server/src/controllers/analytics_controller.ts
@@ -659,9 +659,17 @@ export async function getHSR(
 
     let cache = await AnalyticUnitCache.findById(analyticUnit.id);
     if(
-      cache === null ||
-      cache.data.alpha !== (analyticUnit as AnalyticUnit.AnomalyAnalyticUnit).alpha ||
-      cache.data.confidence !== (analyticUnit as AnalyticUnit.AnomalyAnalyticUnit).confidence
+        cache === null ||
+        analyticUnit.detectorType === AnalyticUnit.DetectorType.ANOMALY &&
+        (
+          cache.data.alpha !== (analyticUnit as AnalyticUnit.AnomalyAnalyticUnit).alpha ||
+          cache.data.confidence !== (analyticUnit as AnalyticUnit.AnomalyAnalyticUnit).confidence
+        ) ||
+        analyticUnit.detectorType === AnalyticUnit.DetectorType.THRESHOLD &&
+        (
+          cache.data.value !== (analyticUnit as AnalyticUnit.ThresholdAnalyticUnit).value ||
+          cache.data.condition !== (analyticUnit as AnalyticUnit.ThresholdAnalyticUnit).condition
+        )
     ) {
       await runLearning(analyticUnit.id, from, to);
       cache = await AnalyticUnitCache.findById(analyticUnit.id);

--- a/server/src/controllers/analytics_controller.ts
+++ b/server/src/controllers/analytics_controller.ts
@@ -655,7 +655,7 @@ export async function getHSR(
     }
 
     let cache = await AnalyticUnitCache.findById(analyticUnit.id);
-    if(cache === null || analyticCacheOutdated(analyticUnit, cache)) {
+    if(cache === null || cache.isCacheOutdated(analyticUnit)) {
       await runLearning(analyticUnit.id, from, to);
       cache = await AnalyticUnitCache.findById(analyticUnit.id);
     }
@@ -691,10 +691,4 @@ export async function getHSR(
     await AnalyticUnit.setStatus(analyticUnit.id, AnalyticUnit.AnalyticUnitStatus.FAILED, message);
     throw new Error(message);
   }
-}
-
-function analyticCacheOutdated(analyticUnit: AnalyticUnit.AnalyticUnit, cache: AnalyticUnitCache.AnalyticUnitCache) {
-  return !_.every(
-    _.keys(analyticUnit.analyticProps).map(k => _.isEqual(analyticUnit.analyticProps[k], cache.data[k]))
-  );
 }

--- a/server/src/controllers/analytics_controller.ts
+++ b/server/src/controllers/analytics_controller.ts
@@ -4,7 +4,6 @@ import * as AnalyticUnitCache from '../models/analytic_unit_cache_model';
 import * as Segment from '../models/segment_model';
 import * as AnalyticUnit from '../models/analytic_units';
 import * as Detection from '../models/detection_model';
-import { ThresholdAnalyticUnit } from '../models/analytic_units/threshold_analytic_unit_model';
 import { AnalyticsService } from '../services/analytics_service';
 import { AlertService } from '../services/alert_service';
 import { HASTIC_API_KEY } from '../config';
@@ -14,10 +13,7 @@ import { getNonIntersectedSpans } from '../utils/spans';
 
 import { queryByMetric, GrafanaUnavailable, DatasourceUnavailable } from 'grafana-datasource-kit';
 
-
 import * as _ from 'lodash';
-import { WebhookType } from '../services/notification_service';
-import { AnomalyAnalyticUnit } from '../models/analytic_units/anomaly_analytic_unit_model';
 
 const SECONDS_IN_MINUTE = 60;
 
@@ -275,21 +271,21 @@ export async function runLearning(id: AnalyticUnit.AnalyticUnitId, from?: number
         break;
       case AnalyticUnit.DetectorType.THRESHOLD:
         taskPayload.threshold = {
-          value: (analyticUnit as ThresholdAnalyticUnit).value,
-          condition: (analyticUnit as ThresholdAnalyticUnit).condition
+          value: (analyticUnit as AnalyticUnit.ThresholdAnalyticUnit).value,
+          condition: (analyticUnit as AnalyticUnit.ThresholdAnalyticUnit).condition
         };
         taskPayload.data = await getPayloadData(analyticUnit, from, to);
         break;
       case AnalyticUnit.DetectorType.ANOMALY:
         taskPayload.anomaly = {
-          alpha: (analyticUnit as AnomalyAnalyticUnit).alpha,
-          confidence: (analyticUnit as AnomalyAnalyticUnit).confidence,
-          enableBounds: (analyticUnit as AnomalyAnalyticUnit).enableBounds
+          alpha: (analyticUnit as AnalyticUnit.AnomalyAnalyticUnit).alpha,
+          confidence: (analyticUnit as AnalyticUnit.AnomalyAnalyticUnit).confidence,
+          enableBounds: (analyticUnit as AnalyticUnit.AnomalyAnalyticUnit).enableBounds
         };
 
         taskPayload.data = await getPayloadData(analyticUnit, from, to);
 
-        const seasonality = (analyticUnit as AnomalyAnalyticUnit).seasonality;
+        const seasonality = (analyticUnit as AnalyticUnit.AnomalyAnalyticUnit).seasonality;
         if(seasonality > 0) {
           let segments = await Segment.findMany(id, { deleted: true });
           if(segments.length === 0) {

--- a/server/src/controllers/analytics_controller.ts
+++ b/server/src/controllers/analytics_controller.ts
@@ -658,19 +658,8 @@ export async function getHSR(
     }
 
     let cache = await AnalyticUnitCache.findById(analyticUnit.id);
-    if(
-        cache === null ||
-        analyticUnit.detectorType === AnalyticUnit.DetectorType.ANOMALY &&
-        (
-          cache.data.alpha !== (analyticUnit as AnalyticUnit.AnomalyAnalyticUnit).alpha ||
-          cache.data.confidence !== (analyticUnit as AnalyticUnit.AnomalyAnalyticUnit).confidence
-        ) ||
-        analyticUnit.detectorType === AnalyticUnit.DetectorType.THRESHOLD &&
-        (
-          cache.data.value !== (analyticUnit as AnalyticUnit.ThresholdAnalyticUnit).value ||
-          cache.data.condition !== (analyticUnit as AnalyticUnit.ThresholdAnalyticUnit).condition
-        )
-    ) {
+    const analyticFields = analyticUnit.getAnalyticFields();
+    if(cache === null || !_.every(_.keys(analyticFields).map(k => analyticFields[k] === cache.data[k]))) {
       await runLearning(analyticUnit.id, from, to);
       cache = await AnalyticUnitCache.findById(analyticUnit.id);
     }

--- a/server/src/models/analytic_unit_cache_model.ts
+++ b/server/src/models/analytic_unit_cache_model.ts
@@ -1,4 +1,4 @@
-import { AnalyticUnitId } from './analytic_units';
+import { AnalyticUnitId, AnalyticUnit } from './analytic_units';
 import { Collection, makeDBQ } from '../services/data_service';
 
 import * as _ from 'lodash';
@@ -49,6 +49,11 @@ export class AnalyticUnitCache {
     return 3 * MILLISECONDS_IN_INDEX;
   }
 
+  public isCacheOutdated(analyticUnit: AnalyticUnit) {
+    return !_.every(
+      _.keys(analyticUnit.analyticProps).map(k => _.isEqual(analyticUnit.analyticProps[k], this.data[k]))
+    );
+  }
 }
 
 export async function findById(id: AnalyticUnitId): Promise<AnalyticUnitCache> {

--- a/server/src/models/analytic_unit_cache_model.ts
+++ b/server/src/models/analytic_unit_cache_model.ts
@@ -33,7 +33,11 @@ export class AnalyticUnitCache {
   }
 
   public getIntersection(): number {
-    if(this.data !== null && this.data.windowSize !== undefined) {
+    if(
+        this.data !== undefined &&
+        this.data !== null &&
+        this.data.windowSize !== undefined
+    ) {
       //TODO: return one window size after resolving https://github.com/hastic/hastic-server/issues/508
       if(this.data.timeStep !== undefined) {
         return this.data.windowSize * 2 * this.data.timeStep;

--- a/server/src/models/analytic_unit_cache_model.ts
+++ b/server/src/models/analytic_unit_cache_model.ts
@@ -33,7 +33,7 @@ export class AnalyticUnitCache {
   }
 
   public getIntersection(): number {
-    if(this.data.windowSize !== undefined) {
+    if(this.data !== null && this.data.windowSize !== undefined) {
       //TODO: return one window size after resolving https://github.com/hastic/hastic-server/issues/508
       if(this.data.timeStep !== undefined) {
         return this.data.windowSize * 2 * this.data.timeStep;

--- a/server/src/models/analytic_units/analytic_unit_model.ts
+++ b/server/src/models/analytic_units/analytic_unit_model.ts
@@ -77,6 +77,8 @@ export abstract class AnalyticUnit {
     };
   }
 
-  public getAnalyticFields(): any {};
+  get analyticProps () {
+    return {};
+  }
 
 }

--- a/server/src/models/analytic_units/analytic_unit_model.ts
+++ b/server/src/models/analytic_units/analytic_unit_model.ts
@@ -2,7 +2,6 @@ import { AnalyticUnitId, AnalyticUnitStatus, DetectorType } from './types';
 
 import { Metric } from 'grafana-datasource-kit';
 
-
 export abstract class AnalyticUnit {
 
   public learningAfterUpdateRequired = false;
@@ -77,5 +76,7 @@ export abstract class AnalyticUnit {
       collapsed: this.collapsed
     };
   }
+
+  public getAnalyticFields(): any {};
 
 }

--- a/server/src/models/analytic_units/anomaly_analytic_unit_model.ts
+++ b/server/src/models/analytic_units/anomaly_analytic_unit_model.ts
@@ -59,25 +59,19 @@ export class AnomalyAnalyticUnit extends AnalyticUnit {
 
   toObject() {
     const baseObject = super.toObject();
+    const analyticFilds = this.getAnalyticFields();
     return {
       ...baseObject,
-      alpha: this.alpha,
-      confidence: this.confidence,
-      seasonality: this.seasonality,
-      seasonalityPeriod: this.seasonalityPeriod,
-      enableBounds: this.enableBounds
+      ...analyticFilds
     };
   }
 
   toPanelObject() {
     const baseObject = super.toPanelObject();
+    const analyticFilds = this.getAnalyticFields();
     return {
       ...baseObject,
-      alpha: this.alpha,
-      confidence: this.confidence,
-      seasonality: this.seasonality,
-      seasonalityPeriod: this.seasonalityPeriod,
-      enableBounds: this.enableBounds
+      ...analyticFilds
     };
   }
 
@@ -109,5 +103,15 @@ export class AnomalyAnalyticUnit extends AnalyticUnit {
       obj.visible,
       obj.collapsed
     );
+  }
+
+  public getAnalyticFields(): any {
+    return {
+      alpha: this.alpha,
+      confidence: this.confidence,
+      seasonality: this.seasonality,
+      seasonalityPeriod: this.seasonalityPeriod,
+      enableBounds: this.enableBounds
+    }
   }
 }

--- a/server/src/models/analytic_units/anomaly_analytic_unit_model.ts
+++ b/server/src/models/analytic_units/anomaly_analytic_unit_model.ts
@@ -8,7 +8,7 @@ type SeasonalityPeriod = {
   value: number
 }
 
-enum Bound {
+export enum Bound {
   ALL = 'ALL',
   UPPER = 'UPPER',
   LOWER = 'LOWER'
@@ -103,13 +103,12 @@ export class AnomalyAnalyticUnit extends AnalyticUnit {
     );
   }
 
-
   get analyticProps() {
     return {
       alpha: this.alpha,
       confidence: this.confidence,
       seasonality: this.seasonality,
-      seasonalityPeriod: this.seasonalityPeriod,
+      seasonalityPeriod: this.seasonalityPeriod,  
       enableBounds: this.enableBounds
     };
   }

--- a/server/src/models/analytic_units/anomaly_analytic_unit_model.ts
+++ b/server/src/models/analytic_units/anomaly_analytic_unit_model.ts
@@ -59,19 +59,17 @@ export class AnomalyAnalyticUnit extends AnalyticUnit {
 
   toObject() {
     const baseObject = super.toObject();
-    const analyticFilds = this.getAnalyticFields();
     return {
       ...baseObject,
-      ...analyticFilds
+      ...this.analyticProps
     };
   }
 
   toPanelObject() {
     const baseObject = super.toPanelObject();
-    const analyticFilds = this.getAnalyticFields();
     return {
       ...baseObject,
-      ...analyticFilds
+      ...this.analyticProps
     };
   }
 
@@ -105,13 +103,14 @@ export class AnomalyAnalyticUnit extends AnalyticUnit {
     );
   }
 
-  public getAnalyticFields(): any {
+
+  get analyticProps() {
     return {
       alpha: this.alpha,
       confidence: this.confidence,
       seasonality: this.seasonality,
       seasonalityPeriod: this.seasonalityPeriod,
       enableBounds: this.enableBounds
-    }
+    };
   }
 }

--- a/server/src/models/analytic_units/index.ts
+++ b/server/src/models/analytic_units/index.ts
@@ -2,8 +2,8 @@ import { createAnalyticUnitFromObject } from './utils';
 import { AnalyticUnitId, AnalyticUnitStatus, DetectorType, ANALYTIC_UNIT_TYPES } from './types';
 import { AnalyticUnit } from './analytic_unit_model';
 import { PatternAnalyticUnit } from './pattern_analytic_unit_model';
-import { ThresholdAnalyticUnit } from './threshold_analytic_unit_model';
-import { AnomalyAnalyticUnit } from './anomaly_analytic_unit_model';
+import { ThresholdAnalyticUnit, Condition } from './threshold_analytic_unit_model';
+import { AnomalyAnalyticUnit, Bound } from './anomaly_analytic_unit_model';
 import {
   findById,
   findMany,
@@ -19,8 +19,8 @@ import {
 
 export {
   AnalyticUnit, PatternAnalyticUnit, ThresholdAnalyticUnit, AnomalyAnalyticUnit,
-  AnalyticUnitId, AnalyticUnitStatus, DetectorType, ANALYTIC_UNIT_TYPES,
-  createAnalyticUnitFromObject,
+  AnalyticUnitId, AnalyticUnitStatus, Bound, DetectorType, ANALYTIC_UNIT_TYPES,
+  createAnalyticUnitFromObject, Condition,
   findById, findMany,
   create, remove, update,
   setStatus, setDetectionTime, setAlert, setMetric

--- a/server/src/models/analytic_units/threshold_analytic_unit_model.ts
+++ b/server/src/models/analytic_units/threshold_analytic_unit_model.ts
@@ -56,19 +56,17 @@ export class ThresholdAnalyticUnit extends AnalyticUnit {
 
   toObject() {
     const baseObject = super.toObject();
-    const analyticFilds = this.getAnalyticFields();
     return {
       ...baseObject,
-      ...analyticFilds
+      ...this.analyticProps
     };
   }
 
   toPanelObject() {
     const baseObject = super.toPanelObject();
-    const analyticFilds = this.getAnalyticFields();
     return {
       ...baseObject,
-      ...analyticFilds
+      ...this.analyticProps
     };
   }
 
@@ -99,7 +97,7 @@ export class ThresholdAnalyticUnit extends AnalyticUnit {
     );
   }
 
-  public getAnalyticFields(): any {
+  get analyticProps() {
     return {
       value: this.value,
       condition: this.condition

--- a/server/src/models/analytic_units/threshold_analytic_unit_model.ts
+++ b/server/src/models/analytic_units/threshold_analytic_unit_model.ts
@@ -56,19 +56,19 @@ export class ThresholdAnalyticUnit extends AnalyticUnit {
 
   toObject() {
     const baseObject = super.toObject();
+    const analyticFilds = this.getAnalyticFields();
     return {
       ...baseObject,
-      value: this.value,
-      condition: this.condition
+      ...analyticFilds
     };
   }
 
   toPanelObject() {
     const baseObject = super.toPanelObject();
+    const analyticFilds = this.getAnalyticFields();
     return {
       ...baseObject,
-      value: this.value,
-      condition: this.condition
+      ...analyticFilds
     };
   }
 
@@ -97,5 +97,12 @@ export class ThresholdAnalyticUnit extends AnalyticUnit {
       obj.visible,
       obj.collapsed
     );
+  }
+
+  public getAnalyticFields(): any {
+    return {
+      value: this.value,
+      condition: this.condition
+    }
   }
 }


### PR DESCRIPTION
fixes #739 

## Problem

in `getIntersection` there isn't a check that `this.data` is null. Data will be null when analytic unit haven't got though "learning" stage. It happens when user creates an analytic unit and goes to inspect mode.

## Changes
- added check for `cache.data` === `null` case
- `getHSR`: check threshold's fields for case when threshold needs learning