### PR TITLE
Anomaly detector's segments concatenation #716

### DIFF
--- a/server/spec/segments.jest.ts
+++ b/server/spec/segments.jest.ts
@@ -21,7 +21,7 @@ beforeAll(async () => {
     })
   );
   await AnalyticUnitCache.create(id);
-  await AnalyticUnitCache.setData(id, { timeStep: 0 });
+  await AnalyticUnitCache.setData(id, { timeStep: 1 });
 });
 
 beforeEach(async () => {

--- a/server/spec/segments.jest.ts
+++ b/server/spec/segments.jest.ts
@@ -52,17 +52,14 @@ describe('Check deleted segments', function () {
 });
 
 async function getDeletedSegments(id, payload): Promise<Segment.Segment[]> {
-  let preSegments = await Segment.findMany(id, { labeled: false, deleted: false });
-  console.log(preSegments)
+  const preSegments = await Segment.findMany(id, { labeled: false, deleted: false });
   await deleteNonDetectedSegments(id, payload);
-  let postSegments = await Segment.findMany(id, { labeled: false, deleted: false });
-  console.log(postSegments)
-  let deleted = setDifference(preSegments, postSegments);
-  deleted = deleted.map(s => {
+  const postSegments = await Segment.findMany(id, { labeled: false, deleted: false });
+  const deleted = setDifference(preSegments, postSegments);
+  return deleted.map(s => {
     s.id = undefined;
     return s;
   });
-  return deleted;
 }
 
 function setDifference(a, b: Segment.Segment[]): Segment.Segment[] {

--- a/server/spec/segments.jest.ts
+++ b/server/spec/segments.jest.ts
@@ -5,14 +5,14 @@ import * as AnalyticUnitCache from '../src/models/analytic_unit_cache_model';
 
 import * as _ from 'lodash';
 
-const id: AnalyticUnit.AnalyticUnitId = 'testid';
-const baseSegments = segmentBuilder([[0, 1], [2, 3], [4, 5]]);
+const TEST_ID: AnalyticUnit.AnalyticUnitId = 'testid';
+const INITIAL_SEGMENTS = segmentBuilder([[0, 1], [2, 3], [4, 5]]);
 
 beforeAll(async () => {
   clearDB();
   await AnalyticUnit.create(
     AnalyticUnit.createAnalyticUnitFromObject({
-      _id: id,
+      _id: TEST_ID,
       name: 'name',
       grafanaUrl: 'grafanaUrl',
       panelId: 'panelId',
@@ -20,12 +20,12 @@ beforeAll(async () => {
       detectorType: AnalyticUnit.DetectorType.ANOMALY
     })
   );
-  await AnalyticUnitCache.create(id);
-  await AnalyticUnitCache.setData(id, { timeStep: 1 });
+  await AnalyticUnitCache.create(TEST_ID);
+  await AnalyticUnitCache.setData(TEST_ID, { timeStep: 1 });
 });
 
 beforeEach(async () => {
-  await Segment.insertSegments(baseSegments);
+  await Segment.insertSegments(INITIAL_SEGMENTS);
 });
 
 afterEach(async () => {
@@ -41,20 +41,20 @@ describe('Check deleted segments', function () {
 
   it('previous segments not found', async function () {
     payload.segments = segmentBuilder([[0, 1], [4, 5]]);
-    expect(await getDeletedSegments(id, payload)).toEqual(segmentBuilder([[2, 3]]));
+    expect(await getDeletedSegments(TEST_ID, payload)).toEqual(segmentBuilder([[2, 3]]));
   });
 
   it('all previous segments found', async function () {
     payload.segments = segmentBuilder([[0, 1], [2, 3], [4, 5]]);
-    expect(await getDeletedSegments(id, payload)).toEqual([]);
+    expect(await getDeletedSegments(TEST_ID, payload)).toEqual([]);
   });
 
 });
 
-async function getDeletedSegments(id, payload): Promise<Segment.Segment[]> {
-  const preSegments = await Segment.findMany(id, { labeled: false, deleted: false });
-  await deleteNonDetectedSegments(id, payload);
-  const postSegments = await Segment.findMany(id, { labeled: false, deleted: false });
+async function getDeletedSegments(TEST_ID, payload): Promise<Segment.Segment[]> {
+  const preSegments = await Segment.findMany(TEST_ID, { labeled: false, deleted: false });
+  await deleteNonDetectedSegments(TEST_ID, payload);
+  const postSegments = await Segment.findMany(TEST_ID, { labeled: false, deleted: false });
   const deleted = setDifference(preSegments, postSegments);
   return deleted.map(s => {
     s.id = undefined;
@@ -68,11 +68,11 @@ function setDifference(a, b: Segment.Segment[]): Segment.Segment[] {
 
 function segmentBuilder(times) {
   return times.map(t => {
-    return new Segment.Segment(id, t[0], t[1], false, false, undefined);
+    return new Segment.Segment(TEST_ID, t[0], t[1], false, false, undefined);
   });
 }
 
 async function clearDB() {
-  const segments = await Segment.findMany(id, { labeled: false, deleted: false });
+  const segments = await Segment.findMany(TEST_ID, { labeled: false, deleted: false });
   await Segment.removeSegments(segments.map(s => s.id));
 }

--- a/server/spec/segments.jest.ts
+++ b/server/spec/segments.jest.ts
@@ -32,19 +32,19 @@ afterEach(async () => {
   clearDB();
 });
 
-describe('Check deleted segments', function () {
+describe('Check deleted segments', function() {
   let payload = {
     lastDetectionTime: 0,
     segments: [],
     cache: null
   };
 
-  it('previous segments not found', async function () {
+  it('previous segments not found', async function() {
     payload.segments = segmentBuilder([[0, 1], [4, 5]]);
     expect(await getDeletedSegments(TEST_ID, payload)).toEqual(segmentBuilder([[2, 3]]));
   });
 
-  it('all previous segments found', async function () {
+  it('all previous segments found', async function() {
     payload.segments = segmentBuilder([[0, 1], [2, 3], [4, 5]]);
     expect(await getDeletedSegments(TEST_ID, payload)).toEqual([]);
   });

--- a/server/src/models/analytic_unit_cache_model.ts
+++ b/server/src/models/analytic_unit_cache_model.ts
@@ -49,6 +49,10 @@ export class AnalyticUnitCache {
     return 3 * MILLISECONDS_IN_INDEX;
   }
 
+  public getTimeStep() {
+    return this.data.timeStep;
+  }
+
   public isCacheOutdated(analyticUnit: AnalyticUnit) {
     return !_.every(
       _.keys(analyticUnit.analyticProps).map(k => _.isEqual(analyticUnit.analyticProps[k], this.data[k]))

--- a/server/src/models/analytic_unit_cache_model.ts
+++ b/server/src/models/analytic_unit_cache_model.ts
@@ -49,7 +49,7 @@ export class AnalyticUnitCache {
     return 3 * MILLISECONDS_IN_INDEX;
   }
 
-  public getTimeStep() {
+  public getTimeStep(): number {
     return this.data.timeStep;
   }
 

--- a/server/src/models/detection_model.ts
+++ b/server/src/models/detection_model.ts
@@ -66,6 +66,9 @@ export class DetectionSpan {
 
 export type FindManyQuery = {
   status?: DetectionStatus,
+  // TODO: 
+  // from?: { $gte?: number, $lte?: number }
+  // to?: { $gte?: number, $lte?: number }
   timeFromLTE?: number,
   timeToGTE?: number,
   timeFromGTE?: number,

--- a/server/src/models/segment_model.ts
+++ b/server/src/models/segment_model.ts
@@ -161,6 +161,8 @@ export async function insertSegments(segments: Segment[]) {
 
       if (intersectedWithLeftBound.length > 0) {
         console.info(intersectedWithLeftBound);
+        let leftSegment = intersectedWithLeftBound[0];
+        segment.from = leftSegment.from;
       } else {
         console.info('intersectedWithLeftBound.length == 0');
       }
@@ -174,6 +176,8 @@ export async function insertSegments(segments: Segment[]) {
 
       if (intersectedWithRightBound.length > 0) {
         console.info(intersectedWithRightBound);
+        let rightSegment = intersectedWithRightBound[0];
+        segment.to = rightSegment.to;
       } else {
         console.info('intersectedWithRightBound.length == 0');
       }

--- a/server/src/models/segment_model.ts
+++ b/server/src/models/segment_model.ts
@@ -140,9 +140,9 @@ export async function insertSegments(segments: Segment[]) {
       });
 
       if(intersectedWithLeftBound.length > 0) {
-        let leftSegment = intersectedWithLeftBound[0];
+        const leftSegment = _.minBy(intersectedWithLeftBound, 'from');
         segment.from = leftSegment.from;
-        segmentIdsToRemove.push(intersectedWithLeftBound[0].id);
+        segmentIdsToRemove.push(leftSegment.id);
       }
 
       const intersectedWithRightBound = await findMany(analyticUnitId, {
@@ -152,9 +152,9 @@ export async function insertSegments(segments: Segment[]) {
       });
 
       if(intersectedWithRightBound.length > 0) {
-        let rightSegment = intersectedWithRightBound[0];
+        const rightSegment = _.maxBy(intersectedWithRightBound, 'to');
         segment.to = rightSegment.to;
-        segmentIdsToRemove.push(intersectedWithRightBound[0].id);
+        segmentIdsToRemove.push(rightSegment.id);
       }
     }
 

--- a/server/src/models/segment_model.ts
+++ b/server/src/models/segment_model.ts
@@ -75,7 +75,7 @@ export type FindManyQuery = {
   from?: { $gte?: number, $lte?: number },
   to?: { $gte?: number, $lte?: number },
   labeled?: boolean,
-  deleted?: boolean,
+  deleted?: boolean
 }
 
 export async function findMany(id: AnalyticUnitId, query: FindManyQuery): Promise<Segment[]> {

--- a/server/src/models/segment_model.ts
+++ b/server/src/models/segment_model.ts
@@ -140,7 +140,7 @@ export async function insertSegments(segments: Segment[]) {
       });
 
       if(intersectedWithLeftBound.length > 0) {
-        const leftSegment = _.minBy(intersectedWithLeftBound, 'from');
+        const leftSegment = _.minBy(intersectedWithLeftBound, s => s.from);
         segment.from = leftSegment.from;
         segmentIdsToRemove.push(leftSegment.id);
       }
@@ -152,7 +152,7 @@ export async function insertSegments(segments: Segment[]) {
       });
 
       if(intersectedWithRightBound.length > 0) {
-        const rightSegment = _.maxBy(intersectedWithRightBound, 'to');
+        const rightSegment = _.maxBy(intersectedWithRightBound, s => s.to);
         segment.to = rightSegment.to;
         segmentIdsToRemove.push(rightSegment.id);
       }

--- a/server/src/models/segment_model.ts
+++ b/server/src/models/segment_model.ts
@@ -163,6 +163,7 @@ export async function insertSegments(segments: Segment[]) {
         console.info(intersectedWithLeftBound);
         let leftSegment = intersectedWithLeftBound[0];
         segment.from = leftSegment.from;
+        segmentIdsToRemove = segmentIdsToRemove.concat(intersectedWithLeftBound[0]._id);
       } else {
         console.info('intersectedWithLeftBound.length == 0');
       }
@@ -178,6 +179,7 @@ export async function insertSegments(segments: Segment[]) {
         console.info(intersectedWithRightBound);
         let rightSegment = intersectedWithRightBound[0];
         segment.to = rightSegment.to;
+        segmentIdsToRemove = segmentIdsToRemove.concat(intersectedWithRightBound[0]._id);
       } else {
         console.info('intersectedWithRightBound.length == 0');
       }

--- a/server/src/models/segment_model.ts
+++ b/server/src/models/segment_model.ts
@@ -72,21 +72,14 @@ export class Segment {
 
 export type FindManyQuery = {
   $or?: any,
-  timeFromGTE?: number,
-  timeToLTE?: number,
-  intexGT?: number,
+  from?: { $gte?: number, $lte?: number },
+  to?: { $gte?: number, $lte?: number },
   labeled?: boolean,
-  deleted?: boolean
+  deleted?: boolean,
 }
 
 export async function findMany(id: AnalyticUnitId, query: FindManyQuery): Promise<Segment[]> {
   var dbQuery: any = { analyticUnitId: id };
-  if(query.timeFromGTE !== undefined) {
-    dbQuery.from = { $gte: query.timeFromGTE };
-  }
-  if(query.timeToLTE !== undefined) {
-    dbQuery.to = { $lte: query.timeToLTE };
-  }
   if(query.labeled !== undefined) {
     dbQuery.labeled = query.labeled;
   }
@@ -105,8 +98,7 @@ export async function insertSegments(segments: Segment[]) {
     return [];
   }
   const analyticUnitId: AnalyticUnitId = segments[0].analyticUnitId;
-  const learningSegments: Segment[] = await db.findMany({
-    analyticUnitId,
+  const learningSegments = await findMany(analyticUnitId, {
     labeled: true,
     deleted: false
   });
@@ -123,8 +115,7 @@ export async function insertSegments(segments: Segment[]) {
     }
 
     if(!segment.deleted && !segment.labeled) {
-      const intersectedWithDeletedSegments = await db.findMany({
-        analyticUnitId,
+      const intersectedWithDeletedSegments = await findMany(analyticUnitId, {
         to: { $gte: segment.from },
         from: { $lte: segment.to },
         labeled: false,
@@ -136,54 +127,43 @@ export async function insertSegments(segments: Segment[]) {
       }
     }
 
-    const intersectedSegments = await db.findMany({
-      analyticUnitId,
-      to: { $gte: segment.from },
-      from: { $lte: segment.to },
-      labeled: segment.labeled,
-      deleted: segment.deleted
-    });
-
     let cache = await AnalyticUnitCache.findById(analyticUnitId);
     const timeStep = cache.getTimeStep();
     let unit = await AnalyticUnit.findById(analyticUnitId);
     const detector = unit.detectorType;
-    console.info(detector);
-    console.info('from: ', segment.from, 'to: ', segment.to, 'timestep: ', timeStep );
 
-    if(detector != 'pattern') {
-      const intersectedWithLeftBound = await db.findMany({
-        analyticUnitId,
+    if(detector !== AnalyticUnit.DetectorType.PATTERN) {
+      const intersectedWithLeftBound = await findMany(analyticUnitId, {
         to: { $gte: segment.from - timeStep, $lte: segment.from },
         labeled: false,
         deleted: false
       });
 
-      if (intersectedWithLeftBound.length > 0) {
-        console.info(intersectedWithLeftBound);
+      if(intersectedWithLeftBound.length > 0) {
         let leftSegment = intersectedWithLeftBound[0];
         segment.from = leftSegment.from;
-        segmentIdsToRemove = segmentIdsToRemove.concat(intersectedWithLeftBound[0]._id);
-      } else {
-        console.info('intersectedWithLeftBound.length == 0');
+        segmentIdsToRemove.push(intersectedWithLeftBound[0].id);
       }
 
-      const intersectedWithRightBound = await db.findMany({
-        analyticUnitId,
+      const intersectedWithRightBound = await findMany(analyticUnitId, {
         from: { $gte: segment.to, $lte: segment.to + timeStep },
         labeled: false,
         deleted: false
       });
 
-      if (intersectedWithRightBound.length > 0) {
-        console.info(intersectedWithRightBound);
+      if(intersectedWithRightBound.length > 0) {
         let rightSegment = intersectedWithRightBound[0];
         segment.to = rightSegment.to;
-        segmentIdsToRemove = segmentIdsToRemove.concat(intersectedWithRightBound[0]._id);
-      } else {
-        console.info('intersectedWithRightBound.length == 0');
+        segmentIdsToRemove.push(intersectedWithRightBound[0].id);
       }
     }
+
+    const intersectedSegments = await findMany(analyticUnitId, {
+      to: { $gte: segment.from },
+      from: { $lte: segment.to },
+      labeled: segment.labeled,
+      deleted: segment.deleted
+    });
 
     if(intersectedSegments.length > 0) {
       let from = _.minBy(intersectedSegments, 'from').from;
@@ -191,7 +171,7 @@ export async function insertSegments(segments: Segment[]) {
       let newSegment = Segment.fromObject(segment.toObject());
       newSegment.from = from;
       newSegment.to = to;
-      segmentIdsToRemove = segmentIdsToRemove.concat(intersectedSegments.map(s => s._id));
+      segmentIdsToRemove = segmentIdsToRemove.concat(intersectedSegments.map(s => s.id));
       segmentsToInsert.push(newSegment);
     } else {
       segmentsToInsert.push(segment);

--- a/server/src/routes/segments_router.ts
+++ b/server/src/routes/segments_router.ts
@@ -13,14 +13,11 @@ async function getSegments(ctx: Router.IRouterContext) {
   }
   let query: Segment.FindManyQuery = {};
 
-  if(!isNaN(+ctx.request.query.lastSegmentId)) {
-    query.intexGT = +ctx.request.query.lastSegmentId;
-  }
   if(!isNaN(+ctx.request.query.from)) {
-    query.timeFromGTE = +ctx.request.query.from;
+    query.from = { $gte: +ctx.request.query.from };
   }
   if(!isNaN(+ctx.request.query.to)) {
-    query.timeToLTE = +ctx.request.query.to;
+    query.to = { $lte: +ctx.request.query.to };
   }
   let segments = await Segment.findMany(id, query);
   ctx.response.body = { segments };


### PR DESCRIPTION
## PROBLEM

Anomaly / threshold segments detected using webhooks are not merged, even if they are near (timestep from each other).

## REASON
For example, server sent several anomaly chunks in a row. Analytics doesn't khow about previous chunks and can't merge them. Server doesn't merge them too.

## SOLUTION
Server must check nearest segments and merge them before insertion into DB.
We have two segments: `[segment.from - timestep, segment.from]` and `[segment.to, segment.to + timestep]`.
![1](https://user-images.githubusercontent.com/39257464/62797823-4e925200-bae5-11e9-83dc-3683b92ea91c.png)
Server must find segment with `segment.to` in `[segment.from - timestep, segment.from]`
and segment with `segment.from` in `[segment.to, segment.to + timestep]`.

### remark(!): that logic is correct for anomaly and threshold analytic units, not pattern.

## CHANGES
- find intersection of inserted segment with segments in the DB (`[segment.from - timestep, segment.from]` and `[segment.to, segment.to + timestep]`
- update segments if there are intersected segments
- remove old segments from DB
- fix tests