### PR TITLE
Update grafana-datasource-kit to 0.1.17

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -38,7 +38,7 @@
     "es6-promise": "^4.2.4",
     "event-stream": "3.3.4",
     "file-loader": "^1.1.11",
-    "grafana-datasource-kit": "0.1.16",
+    "grafana-datasource-kit": "0.1.17",
     "jest": "^23.1.1",
     "koa": "^2.0.46",
     "koa-bodyparser": "^4.2.0",


### PR DESCRIPTION
Fixes #715 

`Cannot set property 'gte' of undefined #715` is fixed in https://github.com/CorpGlory/grafana-datasource-kit/pull/82 which is released in grafana-datasource-kit v0.1.17

## Changes
- update grafana-datasource-kit to 0.1.17