### PR TITLE
Tests for detection-spans

### DIFF
--- a/server/spec/models/detection_model.jest.ts
+++ b/server/spec/models/detection_model.jest.ts
@@ -31,7 +31,7 @@ describe('insertSpan', () => {
   });
 
 
-  it('should merge spans if existing span is inside the one we`re trying to insert', async () => {
+  it('should merge spans if existing span is inside the one being inserted', async () => {
     await insertSpans([
       { from: 1, to: 6, status: Detection.DetectionStatus.RUNNING }
     ]);

--- a/server/spec/models/detection_model.jest.ts
+++ b/server/spec/models/detection_model.jest.ts
@@ -46,7 +46,7 @@ describe('insertSpan', () => {
 });
 
 describe('getIntersectedSpans', () => {
-  it('should find intersections correctly', async () => {
+  it('should find all intersections with the inserted span', async () => {
     const testCases = [
       {
         from: 1, to: 5,

--- a/server/spec/models/detection_model.jest.ts
+++ b/server/spec/models/detection_model.jest.ts
@@ -5,13 +5,13 @@ import * as Detection from '../../src/models/detection_model';
 
 import * as _ from 'lodash';
 
-const INITIAL_SPANS = [
+const INITIAL_SPANS_CONFIGS = [
   { from: 1, to: 3, status: Detection.DetectionStatus.READY },
   { from: 4, to: 5, status: Detection.DetectionStatus.RUNNING }
 ];
 
 beforeEach(async () => {
-  await insertSpans(INITIAL_SPANS);
+  await insertSpans(INITIAL_SPANS_CONFIGS);
 });
 
 afterEach(clearSpansDB);
@@ -69,7 +69,7 @@ describe('getIntersectedSpans', () => {
 
 describe('getSpanBorders', () => {
   it('should find span borders correctly', () => {
-    const borders = Detection.getSpanBorders(buildSpans(INITIAL_SPANS));
+    const borders = Detection.getSpanBorders(buildSpans(INITIAL_SPANS_CONFIGS));
     expect(borders).toEqual([1, 3, 3, 4]);
   });
 });

--- a/server/spec/models/detection_model.jest.ts
+++ b/server/spec/models/detection_model.jest.ts
@@ -68,7 +68,7 @@ describe('getIntersectedSpans', () => {
 });
 
 describe('getSpanBorders', () => {
-  it('should find span borders correctly', () => {
+  it('should sort and find span borders', () => {
     const borders = Detection.getSpanBorders(buildSpans(INITIAL_SPANS_CONFIGS));
     expect(borders).toEqual([1, 3, 3, 4]);
   });

--- a/server/spec/models/detection_model.jest.ts
+++ b/server/spec/models/detection_model.jest.ts
@@ -1,0 +1,67 @@
+import { TEST_ANALYTIC_UNIT_ID } from '../utils_for_tests/analytic_units';
+import { buildSpans, clearSpansDB, convertSpansToOptions } from '../utils_for_tests/detection_spans';
+
+import * as Detection from '../../src/models/detection_model';
+
+import * as _ from 'lodash';
+
+const INITIAL_SPANS = buildSpans([
+  { from: 1, to: 3, status: Detection.DetectionStatus.READY },
+  { from: 3, to: 4, status: Detection.DetectionStatus.RUNNING }
+]);
+
+beforeEach(async () => {
+  const insertPromises = INITIAL_SPANS.map(async span => Detection.insertSpan(span));
+  await Promise.all(insertPromises);
+});
+
+afterEach(async () => {
+  await clearSpansDB();
+});
+
+describe('insertSpan', () => {
+  it('should merge spans correctly', async () => {
+    const spansToInsert = buildSpans([
+      { from: 3, to: 4, status: Detection.DetectionStatus.READY },
+      { from: 1, to: 5, status: Detection.DetectionStatus.RUNNING }
+    ]);
+    const insertPromises = spansToInsert.map(async span => Detection.insertSpan(span));
+    await Promise.all(insertPromises);
+
+    const expectedSpans = [
+      { from: 1, to: 4, status: Detection.DetectionStatus.READY }
+    ];
+    const spansInDB = await Detection.findMany(TEST_ANALYTIC_UNIT_ID, { });
+    const spansOptions = convertSpansToOptions(spansInDB);
+    expect(spansOptions).toEqual(expectedSpans);
+  });
+});
+
+describe('getIntersectedSpans', () => {
+  it('should find intersections correctly', async () => {
+    const testCases = [
+      {
+        from: 1, to: 5,
+        expected: [
+          { from: 1, to: 3, status: Detection.DetectionStatus.READY },
+          { from: 3, to: 4, status: Detection.DetectionStatus.RUNNING }
+        ]
+      },
+      { from: 4, to: 5, expected: [{ from: 3, to: 4, status: Detection.DetectionStatus.RUNNING }] },
+      { from: 6, to: 7, expected: [] }
+    ]
+
+    for(let testCase of testCases) {
+      const intersectedSpans = await Detection.getIntersectedSpans(TEST_ANALYTIC_UNIT_ID, testCase.from, testCase.to);
+      const intersectedSpansOptions = convertSpansToOptions(intersectedSpans);
+      expect(intersectedSpansOptions).toEqual(testCase.expected);
+    }
+  });
+});
+
+describe('getSpanBorders', () => {
+  it('should find span borders correctly', () => {
+    const borders = Detection.getSpanBorders(INITIAL_SPANS);
+    expect(borders).toEqual([1, 3, 3, 4]);
+  });
+});

--- a/server/spec/models/detection_model.jest.ts
+++ b/server/spec/models/detection_model.jest.ts
@@ -15,9 +15,7 @@ beforeEach(async () => {
   await Promise.all(insertPromises);
 });
 
-afterEach(async () => {
-  await clearSpansDB();
-});
+afterEach(clearSpansDB);
 
 describe('insertSpan', () => {
   it('should merge spans correctly', async () => {

--- a/server/spec/utils_for_tests/detection_spans.ts
+++ b/server/spec/utils_for_tests/detection_spans.ts
@@ -12,6 +12,12 @@ export function buildSpans(options: DetectionSpanOptions[]): Detection.Detection
   });
 }
 
+export async function insertSpans(options: DetectionSpanOptions[]): Promise<void> {
+  const spansToInsert = buildSpans(options);
+  const insertPromises = spansToInsert.map(async span => Detection.insertSpan(span));
+  await Promise.all(insertPromises);
+}
+
 export function convertSpansToOptions(spans: Detection.DetectionSpan[]): DetectionSpanOptions[] {
   const spansOptions = spans.map(span => ({ from: span.from, to: span.to, status: span.status }));
   return _.sortBy(spansOptions, spanOptions => spanOptions.from);

--- a/server/spec/utils_for_tests/detection_spans.ts
+++ b/server/spec/utils_for_tests/detection_spans.ts
@@ -1,0 +1,22 @@
+import { TEST_ANALYTIC_UNIT_ID } from './analytic_units';
+
+import * as Detection from '../../src/models/detection_model';
+
+import * as _ from 'lodash';
+
+export type DetectionSpanOptions = { from: number, to: number, status: Detection.DetectionStatus };
+
+export function buildSpans(options: DetectionSpanOptions[]): Detection.DetectionSpan[] {
+  return options.map(option => {
+    return new Detection.DetectionSpan(TEST_ANALYTIC_UNIT_ID, option.from, option.to, option.status);
+  });
+}
+
+export function convertSpansToOptions(spans: Detection.DetectionSpan[]): DetectionSpanOptions[] {
+  const spansOptions = spans.map(span => ({ from: span.from, to: span.to, status: span.status }));
+  return _.sortBy(spansOptions, spanOptions => spanOptions.from);
+}
+
+export async function clearSpansDB(): Promise<void> {
+  await Detection.clearSpans(TEST_ANALYTIC_UNIT_ID);
+}

--- a/server/src/models/detection_model.ts
+++ b/server/src/models/detection_model.ts
@@ -13,6 +13,12 @@ export enum DetectionStatus {
 
 export type DetectionId = string;
 
+/**
+ * Detection-span represents the state of dataset segment:
+ * - READY: detection is done
+ * - RUNNING: detection is running
+ * - FAILED: detection failed
+ */
 export class DetectionSpan {
   constructor(
     public analyticUnitId: AnalyticUnitId,

--- a/server/src/models/detection_model.ts
+++ b/server/src/models/detection_model.ts
@@ -2,6 +2,7 @@ import { AnalyticUnitId } from './analytic_units';
 import { Collection, makeDBQ } from '../services/data_service';
 
 import * as _ from 'lodash';
+import { getNonIntersectedSpans } from '../utils/spans';
 
 let db = makeDBQ(Collection.DETECTION_SPANS);
 
@@ -136,6 +137,10 @@ export async function insertSpan(span: DetectionSpan) {
   return db.insertOne(spanToInsert);
 }
 
+/**
+ * Sorts spans by `from` field and @returns an array of their borders 
+ */
+// TODO: remove after getNonIntersectedSpans refactoring
 export function getSpanBorders(spans: DetectionSpan[]): number[] {
   let spanBorders: number[] = [];
 

--- a/server/src/utils/spans.ts
+++ b/server/src/utils/spans.ts
@@ -7,6 +7,7 @@ export declare type Span = {
   to: number
 }
 
+// TODO: move from utils and refactor
 export function getNonIntersectedSpans(from: number, to: number, spanBorders: number[]): Span[] {
   // spanBorders array must be sorted ascending
   let isFromProcessed = false;


### PR DESCRIPTION
Cover `detection_model.ts` with tests.

## Changes
- tests for:
  - `insertSpan`
  - `getIntersectedSpans`
  - `getSpanBorders`

P.S. `insertSpan` test doesn't pass. We can't merge `RUNNING` spans with `READY` if they're intersected. Though we must merge them if span in the DB is inside the one we want to insert.