### PR TITLE
Detection model fixes

### DIFF
--- a/server/spec/models/detection_model.jest.ts
+++ b/server/spec/models/detection_model.jest.ts
@@ -5,18 +5,15 @@ import * as Detection from '../../src/models/detection_model';
 
 import * as _ from 'lodash';
 
-const INITIAL_SPANS_CONFIGS = [
-  { from: 1, to: 3, status: Detection.DetectionStatus.READY },
-  { from: 4, to: 5, status: Detection.DetectionStatus.RUNNING }
-];
-
-beforeEach(async () => {
-  await insertSpans(INITIAL_SPANS_CONFIGS);
-});
-
 afterEach(clearSpansDB);
 
 describe('insertSpan', () => {
+  beforeEach(async () => {
+    await insertSpans([
+      { from: 1, to: 3, status: Detection.DetectionStatus.READY },
+      { from: 4, to: 5, status: Detection.DetectionStatus.RUNNING }
+    ]);
+  })
   it('should merge spans with the same status', async () => {
     const insertSteps = [
       { 
@@ -60,6 +57,11 @@ describe('insertSpan', () => {
 
 describe('getIntersectedSpans', () => {
   it('should find all intersections with the inserted span', async () => {
+    await insertSpans([
+      { from: 1, to: 3, status: Detection.DetectionStatus.READY },
+      { from: 4, to: 5, status: Detection.DetectionStatus.RUNNING }
+    ]);
+
     const testCases = [
       {
         from: 1, to: 5,

--- a/server/spec/models/detection_model.jest.ts
+++ b/server/spec/models/detection_model.jest.ts
@@ -52,7 +52,7 @@ describe('getIntersectedSpans', () => {
         from: 1, to: 5,
         expected: [
           { from: 1, to: 3, status: Detection.DetectionStatus.READY },
-          { from: 3, to: 4, status: Detection.DetectionStatus.RUNNING }
+          { from: 4, to: 5, status: Detection.DetectionStatus.RUNNING }
         ]
       },
       { from: 4, to: 5, expected: [{ from: 3, to: 4, status: Detection.DetectionStatus.RUNNING }] },

--- a/server/spec/models/detection_model.jest.ts
+++ b/server/spec/models/detection_model.jest.ts
@@ -8,24 +8,29 @@ import * as _ from 'lodash';
 afterEach(clearSpansDB);
 
 describe('insertSpan', () => {
-  beforeEach(async () => {
-    await insertSpans([
-      { from: 1, to: 3, status: Detection.DetectionStatus.READY },
-      { from: 4, to: 5, status: Detection.DetectionStatus.RUNNING }
-    ]);
-  })
   it('should merge spans with the same status', async () => {
+    // Each test step affects the next one because result of insertion stays in the DB
     const insertSteps = [
+      {
+        insert: [
+          { from: 1, to: 3, status: Detection.DetectionStatus.READY },
+          { from: 4, to: 5, status: Detection.DetectionStatus.RUNNING }
+        ],
+        expectedAfterInsertion: [
+          { from: 1, to: 3, status: Detection.DetectionStatus.READY },
+          { from: 4, to: 5, status: Detection.DetectionStatus.RUNNING }
+        ]
+      },
       { 
         insert: [ { from: 5, to: 9, status: Detection.DetectionStatus.RUNNING } ],
-        expected: [
+        expectedAfterInsertion: [
           { from: 1, to: 3, status: Detection.DetectionStatus.READY },
           { from: 4, to: 9, status: Detection.DetectionStatus.RUNNING }
         ] 
       },
       {
         insert: [ { from: 2, to: 5, status: Detection.DetectionStatus.READY } ],
-        expected: [
+        expectedAfterInsertion: [
           { from: 1, to: 5, status: Detection.DetectionStatus.READY },
           { from: 4, to: 9, status: Detection.DetectionStatus.RUNNING }
         ]
@@ -36,7 +41,7 @@ describe('insertSpan', () => {
       await insertSpans(step.insert);
       const spansInDB = await Detection.findMany(TEST_ANALYTIC_UNIT_ID, {});
       const spansOptions = convertSpansToOptions(spansInDB);
-      expect(spansOptions).toEqual(step.expected);
+      expect(spansOptions).toEqual(step.expectedAfterInsertion);
     }
   });
 

--- a/server/spec/models/detection_model.jest.ts
+++ b/server/spec/models/detection_model.jest.ts
@@ -18,16 +18,29 @@ afterEach(clearSpansDB);
 
 describe('insertSpan', () => {
   it('should merge spans with the same status', async () => {
-    await insertSpans([
-      { from: 3, to: 5, status: Detection.DetectionStatus.READY }
-    ]);
-
-    const expectedSpans = [
-      { from: 1, to: 5, status: Detection.DetectionStatus.READY }
+    const testSteps = [
+      { 
+        inserted: [ { from: 5, to: 9, status: Detection.DetectionStatus.RUNNING } ],
+        expected: [
+          { from: 1, to: 3, status: Detection.DetectionStatus.READY },
+          { from: 4, to: 9, status: Detection.DetectionStatus.RUNNING }
+        ] 
+      },
+      {
+        inserted: [{ from: 2, to: 5, status: Detection.DetectionStatus.READY }],
+        expected: [
+          { from: 1, to: 5, status: Detection.DetectionStatus.READY },
+          { from: 4, to: 9, status: Detection.DetectionStatus.RUNNING }
+        ]
+      },
     ];
-    const spansInDB = await Detection.findMany(TEST_ANALYTIC_UNIT_ID, { });
-    const spansOptions = convertSpansToOptions(spansInDB);
-    expect(spansOptions).toEqual(expectedSpans);
+
+    for(let step of testSteps) {
+      await insertSpans(step.inserted);
+      const spansInDB = await Detection.findMany(TEST_ANALYTIC_UNIT_ID, {});
+      const spansOptions = convertSpansToOptions(spansInDB);
+      expect(spansOptions).toEqual(step.expected);
+    }
   });
 
 

--- a/server/spec/models/detection_model.jest.ts
+++ b/server/spec/models/detection_model.jest.ts
@@ -55,7 +55,7 @@ describe('getIntersectedSpans', () => {
           { from: 4, to: 5, status: Detection.DetectionStatus.RUNNING }
         ]
       },
-      { from: 4, to: 5, expected: [{ from: 3, to: 4, status: Detection.DetectionStatus.RUNNING }] },
+      { from: 4, to: 5, expected: [{ from: 4, to: 5, status: Detection.DetectionStatus.RUNNING }] },
       { from: 6, to: 7, expected: [] }
     ]
 

--- a/server/spec/models/detection_model.jest.ts
+++ b/server/spec/models/detection_model.jest.ts
@@ -20,14 +20,14 @@ describe('insertSpan', () => {
   it('should merge spans with the same status', async () => {
     const testSteps = [
       { 
-        inserted: [ { from: 5, to: 9, status: Detection.DetectionStatus.RUNNING } ],
+        insert: [ { from: 5, to: 9, status: Detection.DetectionStatus.RUNNING } ],
         expected: [
           { from: 1, to: 3, status: Detection.DetectionStatus.READY },
           { from: 4, to: 9, status: Detection.DetectionStatus.RUNNING }
         ] 
       },
       {
-        inserted: [{ from: 2, to: 5, status: Detection.DetectionStatus.READY }],
+        insert: [{ from: 2, to: 5, status: Detection.DetectionStatus.READY }],
         expected: [
           { from: 1, to: 5, status: Detection.DetectionStatus.READY },
           { from: 4, to: 9, status: Detection.DetectionStatus.RUNNING }
@@ -36,7 +36,7 @@ describe('insertSpan', () => {
     ];
 
     for(let step of testSteps) {
-      await insertSpans(step.inserted);
+      await insertSpans(step.insert);
       const spansInDB = await Detection.findMany(TEST_ANALYTIC_UNIT_ID, {});
       const spansOptions = convertSpansToOptions(spansInDB);
       expect(spansOptions).toEqual(step.expected);

--- a/server/spec/models/detection_model.jest.ts
+++ b/server/spec/models/detection_model.jest.ts
@@ -9,7 +9,11 @@ afterEach(clearSpansDB);
 
 describe('insertSpan', () => {
   it('should merge spans with the same status', async () => {
-    // Each test step affects the next one because result of insertion stays in the DB
+    /* 
+     * Config for test
+     * insert -- what we want to insert in our test database
+     * expectedAfterInsertion -- expected database state after insertion
+     */
     const insertSteps = [
       {
         insert: [

--- a/server/spec/models/detection_model.jest.ts
+++ b/server/spec/models/detection_model.jest.ts
@@ -18,7 +18,7 @@ afterEach(clearSpansDB);
 
 describe('insertSpan', () => {
   it('should merge spans with the same status', async () => {
-    const testSteps = [
+    const insertSteps = [
       { 
         insert: [ { from: 5, to: 9, status: Detection.DetectionStatus.RUNNING } ],
         expected: [
@@ -27,7 +27,7 @@ describe('insertSpan', () => {
         ] 
       },
       {
-        insert: [{ from: 2, to: 5, status: Detection.DetectionStatus.READY }],
+        insert: [ { from: 2, to: 5, status: Detection.DetectionStatus.READY } ],
         expected: [
           { from: 1, to: 5, status: Detection.DetectionStatus.READY },
           { from: 4, to: 9, status: Detection.DetectionStatus.RUNNING }
@@ -35,7 +35,7 @@ describe('insertSpan', () => {
       },
     ];
 
-    for(let step of testSteps) {
+    for(let step of insertSteps) {
       await insertSpans(step.insert);
       const spansInDB = await Detection.findMany(TEST_ANALYTIC_UNIT_ID, {});
       const spansOptions = convertSpansToOptions(spansInDB);

--- a/server/spec/utils/spans.jest.ts
+++ b/server/spec/utils/spans.jest.ts
@@ -3,7 +3,7 @@ import { cutSpanWithSpans } from '../../src/utils/spans';
 import 'jest';
 
 
-function cutSpan(from: number, to: number, cuts: [number, number][]): number[][] {
+function cutSpan(from: number, to: number, cuts: [number, number][]): [number, number][] {
   return cutSpanWithSpans(
     { from: from, to: to },
     cuts.map(([from, to]) => ({ from, to }))

--- a/server/spec/utils/spans.jest.ts
+++ b/server/spec/utils/spans.jest.ts
@@ -3,7 +3,7 @@ import { cutSpanWithSpans } from '../../src/utils/spans';
 import 'jest';
 
 
-function cutSpan(from: number, to: number, cuts: [number, number][]): [number, number][] {
+function cutSpan(from: number, to: number, cuts: [number, number][]): number[][] {
   return cutSpanWithSpans(
     { from: from, to: to },
     cuts.map(([from, to]) => ({ from, to }))

--- a/server/src/models/detection_model.ts
+++ b/server/src/models/detection_model.ts
@@ -11,7 +11,7 @@ export enum DetectionStatus {
   FAILED = 'FAILED'
 }
 
-export type DetectionId = string;
+export type SpanId = string;
 
 /**
  * Detection-span represents the state of dataset segment:
@@ -25,7 +25,7 @@ export class DetectionSpan {
     public from: number,
     public to: number,
     public status: DetectionStatus,
-    public id?: DetectionId,
+    public id?: SpanId,
   ) {
     if(analyticUnitId === undefined) {
       throw new Error('AnalyticUnitId is undefined');
@@ -115,7 +115,7 @@ export async function getIntersectedSpans(
   return findMany(analyticUnitId, { status, timeFromLTE: to, timeToGTE: from });
 }
 
-export async function insertSpan(span: DetectionSpan) {
+export async function insertSpan(span: DetectionSpan): Promise<SpanId> {
   let spanToInsert = span.toObject();
 
   const intersections = await getIntersectedSpans(span.analyticUnitId, span.from, span.to);


### PR DESCRIPTION
PR https://github.com/hastic/hastic-server/pull/747 has introduced some failing tests
This PR fixes code to pass these tests

## Changes
- `insertSpan` now merges spans if existing span is inside the one being inserted
- one more `insertSpan` test