### PR TITLE
WIP: Utils.spans.cutSpanWithSpans more tests

### DIFF
--- a/server/spec/utils/spans.jest.ts
+++ b/server/spec/utils/spans.jest.ts
@@ -13,7 +13,7 @@ function cutSpan(from: number, to: number, cuts: [number, number][]): [number, n
 describe('cutSpanWithSpans', function() {
 
   it('should find spans in simple non-intersected borders', function() {
-    let cutSpans = [[3, 5], [6, 8], [10, 20]] as [number, number][];
+    let cutSpans = [[3, 4], [6, 8], [11, 20]] as [number, number][];
 
     expect(cutSpan(4, 11, cutSpans)).toEqual([[5, 6], [8, 10]]);
     expect(cutSpan(5, 11, cutSpans)).toEqual([[5, 6], [8, 10]]);
@@ -32,12 +32,15 @@ describe('cutSpanWithSpans', function() {
     expect(cutSpan(4, 10, [])).toEqual([[4, 10]]);
   });
 
+  it('should throw error is cut contains float border', function() {
+    expect(cutSpan(1, 10, [[0.9, 0.0]])).toThrow();
+  });
+
   it('should handle one-point cuts', function() {
-    expect(cutSpan(1, 10, [[5, 5]])).toEqual([[1, 5], [5, 10]]);
-    expect(cutSpan(1, 10, [[1, 1]])).toEqual([[1, 10]]);
-    expect(cutSpan(1, 10, [[10, 10]])).toEqual([[1, 10]]);
+    expect(cutSpan(1, 10, [[5, 5]])).toEqual([[1, 4], [6, 10]]);
+    expect(cutSpan(1, 10, [[1, 1]])).toEqual([[2, 10]]);
+    expect(cutSpan(1, 10, [[10, 10]])).toEqual([[1, 9]]);
     expect(cutSpan(1, 10, [[11, 11]])).toEqual([[1, 10]]);
-    expect(cutSpan(1, 10, [[0.9, 0.0]])).toEqual([[1, 10]]);
   });
 
   it('should handle infitie span and infinite cuts', function() {

--- a/server/spec/utils/spans.jest.ts
+++ b/server/spec/utils/spans.jest.ts
@@ -32,6 +32,14 @@ describe('cutSpanWithSpans', function() {
     expect(cutSpan(4, 10, [])).toEqual([[4, 10]]);
   });
 
+  it('should handle empty one-point cuts', function() {
+    expect(cutSpan(1, 10, [[5, 5]])).toEqual([[1, 5], [5, 10]]);
+    expect(cutSpan(1, 10, [[1, 1]])).toEqual([[1, 10]]);
+    expect(cutSpan(1, 10, [[10, 10]])).toEqual([[1, 10]]);
+    expect(cutSpan(1, 10, [[11, 11]])).toEqual([[1, 10]]);
+    expect(cutSpan(1, 10, [[0.9, 0.0]])).toEqual([[1, 10]]);
+  });
+
   it('should handle case when from and to are inside of one big span', function() {
     expect(cutSpan(4, 10, [[1, 20]])).toEqual([]);
     expect(cutSpan(4, 10, [[1, 10]])).toEqual([]);

--- a/server/spec/utils/spans.jest.ts
+++ b/server/spec/utils/spans.jest.ts
@@ -40,14 +40,6 @@ describe('cutSpanWithSpans', function() {
     expect(cutSpan(1, 10, [[0.9, 0.0]])).toEqual([[1, 10]]);
   });
 
-  it('should handle cuts from point span', function() {
-    expect(cutSpan(1, 1, [[5, 5]])).toEqual([[]]);
-    expect(cutSpan(1, 1, [[1, 1]])).toEqual([[]]);
-    expect(cutSpan(1, 1, [[0, 2]])).toEqual([[]]);
-    expect(cutSpan(1, 1, [[0, 1]])).toEqual([[]]);
-    expect(cutSpan(1, 1, [[1, 0]])).toEqual([[]]);
-  });
-
   it('should handle infitie span and infinite cuts', function() {
     expect(cutSpan(0, Infinity, [[5, 10]])).toEqual([[0, 5], [10, Infinity]]);
     expect(cutSpan(0, 6, [[0, Infinity]])).toEqual([]);
@@ -82,6 +74,15 @@ describe('cutSpanWithSpans', function() {
     expect(cutSpan(0, 20, [[3, 3], [3, Infinity], [3, 3], [4, 4]])).toEqual([[0, 3]]);
     expect(cutSpan(0, 20, [[3, 3], [3, Infinity], [3, 3], [4, 4], [3, 5]])).toEqual([[0, 3]]);
     expect(cutSpan(-Infinity, Infinity, [[3, 3], [3, Infinity], [3, 3], [4, 4], [3, 5]])).toEqual([[-Infinity, 3]]);
+  });
+
+
+  it('should handle cuts from point span', function() {
+    expect(cutSpan(1, 1, [[5, 5]])).toThrowError()
+    expect(cutSpan(1, 1, [[1, 1]])).toEqual([[]]);
+    expect(cutSpan(1, 1, [[0, 2]])).toEqual([[]]);
+    expect(cutSpan(1, 1, [[0, 1]])).toEqual([[]]);
+    expect(cutSpan(1, 1, [[1, 0]])).toEqual([[]]);
   });
 
 });

--- a/server/spec/utils/spans.jest.ts
+++ b/server/spec/utils/spans.jest.ts
@@ -43,6 +43,7 @@ describe('cutSpanWithSpans', function() {
   it('should handle infitie span and infinite cuts', function() {
     expect(cutSpan(0, Infinity, [[5, 10]])).toEqual([[0, 5], [10, Infinity]]);
     expect(cutSpan(0, 6, [[0, Infinity]])).toEqual([]);
+    expect(cutSpan(0, 6, [[1, Infinity]])).toEqual([[0, 1]]);
     expect(cutSpan(-Infinity, Infinity, [[-Infinity, Infinity]])).toEqual([]);
   });
 
@@ -66,6 +67,13 @@ describe('cutSpanWithSpans', function() {
     expect(cutSpan(0, 20, [[3, 11], [3, 12], [3, 10], [3, 15], [3, 14]])).toEqual([[0, 3], [15, 20]]);
     expect(cutSpan(0, 20, [[2, 11], [3, 12]])).toEqual([[0, 2], [12, 20]]);
     expect(cutSpan(0, 20, [[2, 15], [3, 12]])).toEqual([[0, 2], [15, 20]]);
+    expect(cutSpan(0, 20, [[2, 15], [3, 12], [1, 18]])).toEqual([[0, 1], [18, 20]]);
+    expect(cutSpan(0, 20, [[2, 15], [3, Infinity], [1, 18]])).toEqual([[0, 1]]);
+    expect(cutSpan(0, 20, [[3, 3], [3, Infinity]])).toEqual([[0, 3]]);
+    expect(cutSpan(0, 20, [[3, 3], [3, Infinity], [3, 3]])).toEqual([[0, 3]]);
+    expect(cutSpan(0, 20, [[3, 3], [3, Infinity], [3, 3], [4, 4]])).toEqual([[0, 3]]);
+    expect(cutSpan(0, 20, [[3, 3], [3, Infinity], [3, 3], [4, 4], [3, 5]])).toEqual([[0, 3]]);
+    expect(cutSpan(-Infinity, Infinity, [[3, 3], [3, Infinity], [3, 3], [4, 4], [3, 5]])).toEqual([[-Infinity, 3]]);
   });
 
 });

--- a/server/spec/utils/spans.jest.ts
+++ b/server/spec/utils/spans.jest.ts
@@ -40,7 +40,7 @@ describe('cutSpanWithSpans', function() {
     expect(cutSpan(1, 10, [[0.9, 0.0]])).toEqual([[1, 10]]);
   });
 
-  it('should handle when spans are infitie', function() {
+  it('should handle infitie span and infinite cuts', function() {
     expect(cutSpan(0, Infinity, [[5, 10]])).toEqual([[0, 5], [10, Infinity]]);
     expect(cutSpan(0, 6, [[0, Infinity]])).toEqual([]);
     expect(cutSpan(-Infinity, Infinity, [[-Infinity, Infinity]])).toEqual([]);

--- a/server/spec/utils/spans.jest.ts
+++ b/server/spec/utils/spans.jest.ts
@@ -32,12 +32,18 @@ describe('cutSpanWithSpans', function() {
     expect(cutSpan(4, 10, [])).toEqual([[4, 10]]);
   });
 
-  it('should handle empty one-point cuts', function() {
+  it('should handle one-point cuts', function() {
     expect(cutSpan(1, 10, [[5, 5]])).toEqual([[1, 5], [5, 10]]);
     expect(cutSpan(1, 10, [[1, 1]])).toEqual([[1, 10]]);
     expect(cutSpan(1, 10, [[10, 10]])).toEqual([[1, 10]]);
     expect(cutSpan(1, 10, [[11, 11]])).toEqual([[1, 10]]);
     expect(cutSpan(1, 10, [[0.9, 0.0]])).toEqual([[1, 10]]);
+  });
+
+  it('should handle when spans are infitie', function() {
+    expect(cutSpan(0, Infinity, [[5, 10]])).toEqual([[0, 5], [10, Infinity]]);
+    expect(cutSpan(0, 6, [[0, Infinity]])).toEqual([]);
+    expect(cutSpan(-Infinity, Infinity, [[-Infinity, Infinity]])).toEqual([]);
   });
 
   it('should handle case when from and to are inside of one big span', function() {

--- a/server/spec/utils/spans.jest.ts
+++ b/server/spec/utils/spans.jest.ts
@@ -59,7 +59,13 @@ describe('cutSpanWithSpans', function() {
   });
 
   it('should be ready to get overlayed cuts', function() {
-    expect(cutSpan(0, 20, [[3, 5], [4, 10]])).toEqual([[0,3], [10, 20]]);
+    expect(cutSpan(0, 20, [[3, 5], [4, 10]])).toEqual([[0, 3], [10, 20]]);
+    expect(cutSpan(0, 20, [[3, 10], [4, 10]])).toEqual([[0, 3], [10, 20]]);
+    expect(cutSpan(0, 20, [[3, 11], [4, 10]])).toEqual([[0, 3], [11, 20]]);
+    expect(cutSpan(0, 20, [[3, 11], [3, 12]])).toEqual([[0, 3], [12, 20]]);
+    expect(cutSpan(0, 20, [[3, 11], [3, 12], [3, 10], [3, 15], [3, 14]])).toEqual([[0, 3], [15, 20]]);
+    expect(cutSpan(0, 20, [[2, 11], [3, 12]])).toEqual([[0, 2], [12, 20]]);
+    expect(cutSpan(0, 20, [[2, 15], [3, 12]])).toEqual([[0, 2], [15, 20]]);
   });
 
 });

--- a/server/spec/utils/spans.jest.ts
+++ b/server/spec/utils/spans.jest.ts
@@ -40,6 +40,14 @@ describe('cutSpanWithSpans', function() {
     expect(cutSpan(1, 10, [[0.9, 0.0]])).toEqual([[1, 10]]);
   });
 
+  it('should handle cuts from point span', function() {
+    expect(cutSpan(1, 1, [[5, 5]])).toEqual([[]]);
+    expect(cutSpan(1, 1, [[1, 1]])).toEqual([[]]);
+    expect(cutSpan(1, 1, [[0, 2]])).toEqual([[]]);
+    expect(cutSpan(1, 1, [[0, 1]])).toEqual([[]]);
+    expect(cutSpan(1, 1, [[1, 0]])).toEqual([[]]);
+  });
+
   it('should handle infitie span and infinite cuts', function() {
     expect(cutSpan(0, Infinity, [[5, 10]])).toEqual([[0, 5], [10, Infinity]]);
     expect(cutSpan(0, 6, [[0, Infinity]])).toEqual([]);


### PR DESCRIPTION
Just to be sure that the function `Utils.spans.cutSpanWithSpans` works as it should, few more tests added: It will help in future if we want to improve the performance.

This PR changes the [behavior](https://github.com/hastic/hastic-server/pull/755#issuecomment-522265390) of `cutSpanWithSpans` and renames it to `cutSegmentWithSegments`


## New tests:

### One-point cut
If we cut `[1, 10]` with `[5, 5]` , we should get spans `[1, 4]` and `[6, 10]`

### Infinite spans
If we cut `[0, Infinity]` with `[5, 10]`, we should get `[0, 4]` and `[11, Infinity]`

If we cut `[1, 6]` with `[0, Infinity]`, we should get `[]`

If we cut `[0, 6]` with `[1, Infinity]`, we should get `[0, 0]`

If we cut `[-Infinity, Infinity]` with `[-Infinity, Infinity]` we should get `[]`

### Overlapping cuts

There are many combinations where cuts include each other or could be sorted wrong.
Many new combinations added. Including infinite case.
 