### PR TITLE
Mongodb persistence #570 part 2

### DIFF
--- a/server/jest.config.js
+++ b/server/jest.config.js
@@ -19,5 +19,3 @@ module.exports = {
     "<rootDir>/spec/setup_tests.ts"
   ]
 };
-
-process.env.HASTIC_DB_IN_MEMORY = 'true';

--- a/server/package.json
+++ b/server/package.json
@@ -21,6 +21,7 @@
   "homepage": "https://github.com/hastic/hastic-server#readme",
   "dependencies": {},
   "devDependencies": {
+    "@types/axios": "^0.14.0",
     "@types/deasync": "^0.1.0",
     "@types/jest": "^23.3.14",
     "@types/koa": "^2.0.46",
@@ -30,7 +31,6 @@
     "@types/mongodb": "^3.3.1",
     "@types/nedb": "^1.8.0",
     "@types/zeromq": "^4.6.0",
-    "deasync": "^0.1.15",
     "axios": "^0.18.0",
     "babel-core": "^6.26.3",
     "babel-jest": "^23.4.2",
@@ -38,6 +38,7 @@
     "babel-polyfill": "^6.26.0",
     "babel-preset-env": "^1.7.0",
     "babel-preset-es2015": "^6.24.1",
+    "deasync": "^0.1.15",
     "es6-promise": "^4.2.4",
     "event-stream": "3.3.4",
     "file-loader": "^1.1.11",

--- a/server/package.json
+++ b/server/package.json
@@ -21,7 +21,6 @@
   "homepage": "https://github.com/hastic/hastic-server#readme",
   "dependencies": {},
   "devDependencies": {
-    "@types/axios": "^0.14.0",
     "@types/deasync": "^0.1.0",
     "@types/jest": "^23.3.14",
     "@types/koa": "^2.0.46",

--- a/server/spec/setup_tests.ts
+++ b/server/spec/setup_tests.ts
@@ -1,6 +1,4 @@
-import * as AnalyticUnit from '../src/models/analytic_units';
-import * as AnalyticUnitCache from '../src/models/analytic_unit_cache_model';
-import { TEST_ANALYTIC_UNIT_ID, createTestDB } from './utils_for_tests/analytic_units';
+import { createTestDB } from './utils_for_tests/analytic_units';
 import { clearSegmentsDB } from './utils_for_tests/segments';
 
 console.log = jest.fn();
@@ -9,8 +7,12 @@ console.error = jest.fn();
 jest.mock('../src/config.ts', () => ({
   DATA_PATH: 'fake-data-path',
   HASTIC_API_KEY: 'fake-key',
-  ZMQ_IPC_PATH: 'fake-zmq-path'
+  ZMQ_IPC_PATH: 'fake-zmq-path',
+  HASTIC_DB_CONNECTION_TYPE: 'nedb',
+  HASTIC_IN_MEMORY_PERSISTANCE: true
 }));
+
+jest.mock('deasync', () => ({ loopWhile: jest.fn() }));
 
 clearSegmentsDB();
 createTestDB();

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -9,7 +9,7 @@ import * as os from 'os';
 let configFile = path.join(__dirname, '../../config.json');
 let configExists = fs.existsSync(configFile);
 
-export type DataBaseConfig = {
+export type DBConfig = {
   user: string,
   password: string,
   url: string,
@@ -130,7 +130,7 @@ function createZMQConnectionString() {
   return zmq;
 }
 
-function getDbConfig(connectionStr: string): DataBaseConfig {
+function getDbConfig(connectionStr: string): DBConfig {
   const [user, password] = connectionStr.split('@')[0].split(':');
   const [dbName, ...urlParts] = connectionStr.split('@')[1].split('/').reverse();
   const url = urlParts.reverse().join('/');

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -9,6 +9,7 @@ import * as os from 'os';
 let configFile = path.join(__dirname, '../../config.json');
 let configExists = fs.existsSync(configFile);
 
+// TODO: move to data_layer
 export type DBConfig = {
   user: string,
   password: string,
@@ -130,6 +131,7 @@ function createZMQConnectionString() {
   return zmq;
 }
 
+// TODO: move to data_layer
 function getDbConfig(connectionStr: string): DBConfig {
   const [user, password] = connectionStr.split('@')[0].split(':');
   const [dbName, ...urlParts] = connectionStr.split('@')[1].split('/').reverse();

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -13,7 +13,7 @@ export type DataBaseConfig = {
   user: string,
   password: string,
   url: string,
-  db_name: string
+  dbName: string
 }
 
 export const ANALYTICS_PATH = path.join(__dirname, '../../analytics');
@@ -132,14 +132,14 @@ function createZMQConnectionString() {
 
 function getDbConfig(connectionStr: string): DataBaseConfig {
   const [user, password] = connectionStr.split('@')[0].split(':');
-  const [db_name, ...urlParts] = connectionStr.split('@')[1].split('/').reverse();
+  const [dbName, ...urlParts] = connectionStr.split('@')[1].split('/').reverse();
   const url = urlParts.reverse().join('/');
 
   const config = {
     user,
     password,
     url,
-    db_name
+    dbName
   };
   return config;
 }

--- a/server/src/controllers/analytics_controller.ts
+++ b/server/src/controllers/analytics_controller.ts
@@ -592,7 +592,7 @@ export async function getDetectionSpans(
 async function getPayloadData(
   analyticUnit: AnalyticUnit.AnalyticUnit,
   from: number,
-  to:number
+  to: number
 ) {
   let range: TimeRange;
   if(from !== undefined && to !== undefined) {

--- a/server/src/migrations.ts
+++ b/server/src/migrations.ts
@@ -17,7 +17,7 @@ const analyticUnitsDB = makeDBQ(Collection.ANALYTIC_UNITS);
 const analyticUnitCachesDB = makeDBQ(Collection.ANALYTIC_UNIT_CACHES);
 const thresholdsDB = makeDBQ(Collection.THRESHOLD);
 
-const DB_META_ID = "000000000000000000000001"; //24 symbols for mongodb
+const DB_META_ID = '000000000000000000000001'; //24 symbols for mongodb
 
 type DbMeta = {
   revision: number

--- a/server/src/migrations.ts
+++ b/server/src/migrations.ts
@@ -17,7 +17,7 @@ const analyticUnitsDB = makeDBQ(Collection.ANALYTIC_UNITS);
 const analyticUnitCachesDB = makeDBQ(Collection.ANALYTIC_UNIT_CACHES);
 const thresholdsDB = makeDBQ(Collection.THRESHOLD);
 
-const DB_META_ID = '0';
+const DB_META_ID = "000000000000000000000001"; //24 symbols for mongodb
 
 type DbMeta = {
   revision: number

--- a/server/src/routes/analytic_units_router.ts
+++ b/server/src/routes/analytic_units_router.ts
@@ -61,8 +61,9 @@ async function updateUnit(ctx: Router.IRouterContext) {
     throw new Error('Cannot update undefined id');
   }
 
-  const updatedObj = await AnalyticUnit.update(analyticUnitObj.id, analyticUnitObj);
-  const analyticUnit = AnalyticUnit.createAnalyticUnitFromObject(updatedObj);
+  await AnalyticUnit.update(analyticUnitObj.id, analyticUnitObj);
+  // TODO: check if learning need without database query
+  const analyticUnit = await AnalyticUnit.findById(analyticUnitObj.id);
 
   if(analyticUnit.learningAfterUpdateRequired) {
     await AnalyticsController.runLearning(analyticUnitObj.id);

--- a/server/src/routes/analytic_units_router.ts
+++ b/server/src/routes/analytic_units_router.ts
@@ -62,7 +62,7 @@ async function updateUnit(ctx: Router.IRouterContext) {
   }
 
   await AnalyticUnit.update(analyticUnitObj.id, analyticUnitObj);
-  // TODO: check if learning need without database query
+  // TODO: check if learning is necessary without database query
   const analyticUnit = await AnalyticUnit.findById(analyticUnitObj.id);
 
   if(analyticUnit.learningAfterUpdateRequired) {

--- a/server/src/services/data_layer/basedb.ts
+++ b/server/src/services/data_layer/basedb.ts
@@ -1,13 +1,15 @@
 import * as nedb from 'nedb';
 import * as mongodb from 'mongodb';
 
+export type dbCollection = nedb | mongodb.Collection;
+
 export interface dbQueryWrapper {
-  dbInsertOne(collection: nedb | mongodb.Collection, doc: object): Promise<string>;
-  dbInsertMany(nd: nedb | mongodb.Collection, docs: object[]): Promise<string[]>;
-  dbUpdateOne(nd: nedb | mongodb.Collection, query: string | object, updateQuery: object): Promise<void>;
-  dbUpdateMany(nd: nedb | mongodb.Collection, query: string[] | object, updateQuery: object): Promise<void>;
-  dbFindOne(nd: nedb | mongodb.Collection, query: string | object): Promise<any>;
-  dbFindMany(nd: nedb | mongodb.Collection, query: string[] | object, sortQuery: object): Promise<any[]>;
-  dbRemoveOne(nd: nedb | mongodb.Collection, query: string | object): Promise<boolean>;
-  dbRemoveMany(nd: nedb | mongodb.Collection, query: string[] | object): Promise<number>;
+  dbInsertOne(collection: dbCollection, doc: object): Promise<string>;
+  dbInsertMany(nd: dbCollection, docs: object[]): Promise<string[]>;
+  dbUpdateOne(nd: dbCollection, query: string | object, updateQuery: object): Promise<void>;
+  dbUpdateMany(nd: dbCollection, query: string[] | object, updateQuery: object): Promise<void>;
+  dbFindOne(nd: dbCollection, query: string | object): Promise<any>;
+  dbFindMany(nd: dbCollection, query: string[] | object, sortQuery: object): Promise<any[]>;
+  dbRemoveOne(nd: dbCollection, query: string | object): Promise<boolean>;
+  dbRemoveMany(nd: dbCollection, query: string[] | object): Promise<number>;
 }

--- a/server/src/services/data_layer/basedb.ts
+++ b/server/src/services/data_layer/basedb.ts
@@ -5,11 +5,11 @@ export type dbCollection = nedb | mongodb.Collection;
 
 export interface dbQueryWrapper {
   dbInsertOne(collection: dbCollection, doc: object): Promise<string>;
-  dbInsertMany(nd: dbCollection, docs: object[]): Promise<string[]>;
-  dbUpdateOne(nd: dbCollection, query: string | object, updateQuery: object): Promise<void>;
-  dbUpdateMany(nd: dbCollection, query: string[] | object, updateQuery: object): Promise<void>;
-  dbFindOne(nd: dbCollection, query: string | object): Promise<any>;
-  dbFindMany(nd: dbCollection, query: string[] | object, sortQuery: object): Promise<any[]>;
-  dbRemoveOne(nd: dbCollection, query: string | object): Promise<boolean>;
-  dbRemoveMany(nd: dbCollection, query: string[] | object): Promise<number>;
+  dbInsertMany(collection: dbCollection, docs: object[]): Promise<string[]>;
+  dbUpdateOne(collection: dbCollection, query: string | object, updateQuery: object): Promise<void>;
+  dbUpdateMany(collection: dbCollection, query: string[] | object, updateQuery: object): Promise<void>;
+  dbFindOne(collection: dbCollection, query: string | object): Promise<any>;
+  dbFindMany(collection: dbCollection, query: string[] | object, sortQuery: object): Promise<any[]>;
+  dbRemoveOne(collection: dbCollection, query: string | object): Promise<boolean>;
+  dbRemoveMany(collection: dbCollection, query: string[] | object): Promise<number>;
 }

--- a/server/src/services/data_layer/basedb.ts
+++ b/server/src/services/data_layer/basedb.ts
@@ -3,7 +3,7 @@ import * as mongodb from 'mongodb';
 
 export type dbCollection = nedb | mongodb.Collection;
 
-export interface dbQueryWrapper {
+export interface DbQueryWrapper {
   dbInsertOne(collection: dbCollection, doc: object): Promise<string>;
   dbInsertMany(collection: dbCollection, docs: object[]): Promise<string[]>;
   dbUpdateOne(collection: dbCollection, query: string | object, updateQuery: object): Promise<void>;

--- a/server/src/services/data_layer/basedb.ts
+++ b/server/src/services/data_layer/basedb.ts
@@ -1,0 +1,13 @@
+import * as nedb from 'nedb';
+import * as mongodb from 'mongodb';
+
+export interface dbQueryWrapper {
+  dbInsertOne(collection: nedb | mongodb.Collection, doc: object): Promise<string>;
+  dbInsertMany(nd: nedb | mongodb.Collection, docs: object[]): Promise<string[]>;
+  dbUpdateOne(nd: nedb | mongodb.Collection, query: string | object, updateQuery: object): Promise<void>;
+  dbUpdateMany(nd: nedb | mongodb.Collection, query: string[] | object, updateQuery: object): Promise<void>;
+  dbFindOne(nd: nedb | mongodb.Collection, query: string | object): Promise<any>;
+  dbFindMany(nd: nedb | mongodb.Collection, query: string[] | object, sortQuery: object): Promise<any[]>;
+  dbRemoveOne(nd: nedb | mongodb.Collection, query: string | object): Promise<boolean>;
+  dbRemoveMany(nd: nedb | mongodb.Collection, query: string[] | object): Promise<number>;
+}

--- a/server/src/services/data_layer/index.ts
+++ b/server/src/services/data_layer/index.ts
@@ -1,3 +1,4 @@
+import { dbQueryWrapper } from './basedb';
 import { NeDbAdapter } from './nedb';
 import { MongoDbAdapter } from './mongodb';
 

--- a/server/src/services/data_layer/index.ts
+++ b/server/src/services/data_layer/index.ts
@@ -1,14 +1,14 @@
-import { dbQueryWrapper } from './basedb';
-import { NeDbAdapter } from './nedb';
+import { dbQueryWrapper, dbCollection } from './basedb';
+import { NeDbQueryWrapper } from './nedb';
 import { MongoDbQueryWrapper } from './mongodb';
 
 import { HASTIC_DB_CONNECTION_TYPE } from '../../config';
 
-export { NeDbAdapter };
+export { NeDbQueryWrapper, MongoDbQueryWrapper, dbQueryWrapper, dbCollection };
 
-export function getDbAdapter() {
+export function getDbAdapter(): dbQueryWrapper {
   if(HASTIC_DB_CONNECTION_TYPE === 'nedb') {
-    return new NeDbAdapter();
+    return new NeDbQueryWrapper();
   }
   if(HASTIC_DB_CONNECTION_TYPE === 'mongodb') {
     return new MongoDbQueryWrapper();

--- a/server/src/services/data_layer/index.ts
+++ b/server/src/services/data_layer/index.ts
@@ -6,7 +6,7 @@ import { HASTIC_DB_CONNECTION_TYPE } from '../../config';
 
 export { NeDbQueryWrapper, MongoDbQueryWrapper, dbQueryWrapper, dbCollection };
 
-export function getDbAdapter(): dbQueryWrapper {
+export function getDbQueryWrapper(): dbQueryWrapper {
   if(HASTIC_DB_CONNECTION_TYPE === 'nedb') {
     return new NeDbQueryWrapper();
   }

--- a/server/src/services/data_layer/index.ts
+++ b/server/src/services/data_layer/index.ts
@@ -19,5 +19,5 @@ export function getDbQueryWrapper(): DbQueryWrapper {
     return new MongoDbQueryWrapper();
   }
 
-  throw new Error(`Unexpected HASTIC_DB_CONNECTION_TYPE "${HASTIC_DB_CONNECTION_TYPE}", only mongodb or nedb available.`);
+  throw new Error(`"${HASTIC_DB_CONNECTION_TYPE}" HASTIC_DB_CONNECTION_TYPE is not supported. Possible values: "nedb", "mongodb"`);
 }

--- a/server/src/services/data_layer/index.ts
+++ b/server/src/services/data_layer/index.ts
@@ -1,12 +1,12 @@
-import { dbQueryWrapper, dbCollection } from './basedb';
+import { DbQueryWrapper, dbCollection } from './basedb';
 import { NeDbQueryWrapper } from './nedb';
 import { MongoDbQueryWrapper } from './mongodb';
 
 import { HASTIC_DB_CONNECTION_TYPE } from '../../config';
 
-export { NeDbQueryWrapper, MongoDbQueryWrapper, dbQueryWrapper, dbCollection };
+export { NeDbQueryWrapper, MongoDbQueryWrapper, DbQueryWrapper, dbCollection };
 
-export function getDbQueryWrapper(): dbQueryWrapper {
+export function getDbQueryWrapper(): DbQueryWrapper {
   if(HASTIC_DB_CONNECTION_TYPE === 'nedb') {
     return new NeDbQueryWrapper();
   }

--- a/server/src/services/data_layer/index.ts
+++ b/server/src/services/data_layer/index.ts
@@ -1,16 +1,18 @@
 import { dbQueryWrapper } from './basedb';
 import { NeDbAdapter } from './nedb';
-import { MongoDbAdapter } from './mongodb';
+import { MongoDbQueryWrapper } from './mongodb';
 
 import { HASTIC_DB_CONNECTION_TYPE } from '../../config';
 
 export { NeDbAdapter };
 
 export function getDbAdapter() {
-    if(HASTIC_DB_CONNECTION_TYPE === 'nedb') {
-        return new NeDbAdapter();
-    }
-    if(HASTIC_DB_CONNECTION_TYPE === 'mongodb') {
-        return new MongoDbAdapter();
-    }
+  if(HASTIC_DB_CONNECTION_TYPE === 'nedb') {
+    return new NeDbAdapter();
+  }
+  if(HASTIC_DB_CONNECTION_TYPE === 'mongodb') {
+    return new MongoDbQueryWrapper();
+  }
+
+  throw new Error(`Unexpected db connection type ${HASTIC_DB_CONNECTION_TYPE}, only mongodb or nedb available.`);
 }

--- a/server/src/services/data_layer/index.ts
+++ b/server/src/services/data_layer/index.ts
@@ -19,5 +19,7 @@ export function getDbQueryWrapper(): DbQueryWrapper {
     return new MongoDbQueryWrapper();
   }
 
-  throw new Error(`"${HASTIC_DB_CONNECTION_TYPE}" HASTIC_DB_CONNECTION_TYPE is not supported. Possible values: "nedb", "mongodb"`);
+  throw new Error(
+    `"${HASTIC_DB_CONNECTION_TYPE}" HASTIC_DB_CONNECTION_TYPE is not supported. Possible values: "nedb", "mongodb"`
+  );
 }

--- a/server/src/services/data_layer/index.ts
+++ b/server/src/services/data_layer/index.ts
@@ -1,0 +1,15 @@
+import { NeDbAdapter } from './nedb';
+import { MongoDbAdapter } from './mongodb';
+
+import { HASTIC_DB_CONNECTION_TYPE } from '../../config';
+
+export { NeDbAdapter };
+
+export function getDbAdapter() {
+    if(HASTIC_DB_CONNECTION_TYPE === 'nedb') {
+        return new NeDbAdapter();
+    }
+    if(HASTIC_DB_CONNECTION_TYPE === 'mongodb') {
+        return new MongoDbAdapter();
+    }
+}

--- a/server/src/services/data_layer/index.ts
+++ b/server/src/services/data_layer/index.ts
@@ -4,15 +4,20 @@ import { MongoDbQueryWrapper } from './mongodb';
 
 import { HASTIC_DB_CONNECTION_TYPE } from '../../config';
 
+export enum DBType {
+  nedb = 'nedb',
+  mongodb = 'mongodb'
+};
+
 export { NeDbQueryWrapper, MongoDbQueryWrapper, DbQueryWrapper, dbCollection };
 
 export function getDbQueryWrapper(): DbQueryWrapper {
-  if(HASTIC_DB_CONNECTION_TYPE === 'nedb') {
+  if(HASTIC_DB_CONNECTION_TYPE === DBType.nedb) {
     return new NeDbQueryWrapper();
   }
-  if(HASTIC_DB_CONNECTION_TYPE === 'mongodb') {
+  if(HASTIC_DB_CONNECTION_TYPE === DBType.mongodb) {
     return new MongoDbQueryWrapper();
   }
 
-  throw new Error(`Unexpected db connection type ${HASTIC_DB_CONNECTION_TYPE}, only mongodb or nedb available.`);
+  throw new Error(`Unexpected HASTIC_DB_CONNECTION_TYPE "${HASTIC_DB_CONNECTION_TYPE}", only mongodb or nedb available.`);
 }

--- a/server/src/services/data_layer/mongodb.ts
+++ b/server/src/services/data_layer/mongodb.ts
@@ -6,7 +6,7 @@ import { wrapIdToMongoDbQuery, wrapIdsToMongoDbQuery, isEmptyArray } from './uti
 import * as _ from 'lodash';
 
 
-export class MongoDbAdapter implements dbQueryWrapper {
+export class MongoDbQueryWrapper implements dbQueryWrapper {
 
   async dbInsertOne(nd: Collection, doc: object): Promise<string> {
     // http://mongodb.github.io/node-mongodb-native/3.1/api/Collection.html#insertOne

--- a/server/src/services/data_layer/mongodb.ts
+++ b/server/src/services/data_layer/mongodb.ts
@@ -1,5 +1,5 @@
 import { Collection, FilterQuery, ObjectID } from 'mongodb';
-import { wrapIdToQuery, wrapIdsToQuery, isEmptyArray } from './utils';
+import { wrapIdToMongoDbQuery, wrapIdsToMongoDbQuery, isEmptyArray } from './utils';
 
 import * as _ from 'lodash';
 
@@ -24,7 +24,7 @@ export class MongoDbAdapter {
   async dbUpdateOne(nd: Collection, query: FilterQuery<string | object>, updateQuery: object): Promise<void> {
     // http://mongodb.github.io/node-mongodb-native/3.1/api/Collection.html#updateOne
     let mongodbUpdateQuery = { $set: updateQuery }
-    query = wrapIdToQuery(query);
+    query = wrapIdToMongoDbQuery(query);
     const affected = await nd.updateOne(
       query,
       mongodbUpdateQuery
@@ -37,7 +37,7 @@ export class MongoDbAdapter {
       return Promise.resolve();
       }
       let mongodbUpdateQuery = { $set: updateQuery };
-      query = wrapIdsToQuery(query);
+      query = wrapIdsToMongoDbQuery(query);
       const affectedDocuments = await collection.updateMany(
           query,
           mongodbUpdateQuery
@@ -46,10 +46,7 @@ export class MongoDbAdapter {
   
   async dbFindOne(collection: Collection, query: FilterQuery<string | object>): Promise<any> {
     // http://mongodb.github.io/node-mongodb-native/3.1/api/Collection.html#findOne
-    if(typeof query === 'string') {
-      query = new ObjectID(query as string);
-    }
-    query = wrapIdToQuery(query);
+    query = wrapIdToMongoDbQuery(query);
     let doc = await collection.findOne(query);
     if(doc !== null) {
       doc._id = doc._id.toString();
@@ -62,13 +59,13 @@ export class MongoDbAdapter {
     if(isEmptyArray(query)) {
       return Promise.resolve([]);
     }
-    query = wrapIdsToQuery(query);
+    query = wrapIdsToMongoDbQuery(query);
     return await collection.find(query).sort(sortQuery).toArray();
   }
   
   async dbRemoveOne(collection: Collection, query: FilterQuery<string | object>): Promise<boolean> {
     // http://mongodb.github.io/node-mongodb-native/3.1/api/Collection.html#deleteOne
-    query = wrapIdToQuery(query);
+    query = wrapIdToMongoDbQuery(query);
     const deleted = await collection.deleteOne(query);
     if(deleted.deletedCount > 1) {
       throw new Error(`Removed ${deleted.deletedCount} elements with query: ${JSON.stringify(query)}. Only one is Ok.`);
@@ -81,7 +78,7 @@ export class MongoDbAdapter {
     if(isEmptyArray(query)) {
       return Promise.resolve(0);
     }
-    query = wrapIdsToQuery(query);
+    query = wrapIdsToMongoDbQuery(query);
     const deleted = await collection.deleteMany(query);
     return deleted.deletedCount;
   }

--- a/server/src/services/data_layer/mongodb.ts
+++ b/server/src/services/data_layer/mongodb.ts
@@ -1,0 +1,89 @@
+import { Collection, FilterQuery, ObjectID } from 'mongodb';
+import { wrapIdToQuery, wrapIdsToQuery, isEmptyArray } from './utils';
+
+import * as _ from 'lodash';
+import { strict } from 'assert';
+
+
+export class MongoDbAdapter {
+
+  async dbInsertOne(nd: Collection, doc: object): Promise<string> {
+    const newDoc = await nd.insertOne(doc);
+    return newDoc.insertedId.toString();
+  }
+  
+  async dbInsertMany(nd: Collection, docs: object[]): Promise<string[]> {
+    if(docs.length === 0) {
+      return Promise.resolve([]);
+    }
+    const newDocs = await nd.insertMany(docs);
+    return _.map(newDocs.insertedIds, (k,v) => v.toString());
+  }
+  
+  async dbUpdateOne(nd: Collection, query: FilterQuery<string | object>, updateQuery: object): Promise<any> {
+    // https://github.com/louischatriot/nedb#updating-documents
+    let mongodbUpdateQuery = { $set: updateQuery }
+    query = wrapIdToQuery(query);
+    const affected = await nd.updateOne(
+      query,
+      mongodbUpdateQuery,
+  //TODO: check follow option: { returnUpdatedDocs: true },
+    );
+    return affected.result; // return updated object
+  }
+  
+  async dbUpdateMany(collection: Collection, query: string[] | object, updateQuery: object): Promise<void> {
+      // https://github.com/louischatriot/nedb#updating-documents
+      if(isEmptyArray(query)) {
+      return Promise.resolve();
+      }
+      let mongodbUpdateQuery = { $set: updateQuery };
+      query = wrapIdsToQuery(query);
+      const affectedDocuments = await collection.updateMany(
+          query,
+          mongodbUpdateQuery
+          //add returnUpdatedDocs: true, 
+      );
+      //?? return updated object
+  }
+  
+  async dbFindOne(collection: Collection, query: FilterQuery<string | object>): Promise<any> {
+    console.log(query);
+    if(typeof query === 'string') {
+      query = new ObjectID(query as string);
+    }
+    query = wrapIdToQuery(query);
+    let doc = await collection.findOne(query);
+    if(doc !== null) {
+      doc._id = doc._id.toString();
+    }
+    return doc;
+
+  }
+  
+  async dbFindMany(collection: Collection, query: string[] | object, sortQuery: object = {}): Promise<any[]> {
+      if(isEmptyArray(query)) {
+      return Promise.resolve([]);
+      }
+      query = wrapIdsToQuery(query);
+      return await collection.find(query).sort(sortQuery).toArray();
+  }
+  
+  async dbRemoveOne(collection: Collection, query: FilterQuery<string | object>): Promise<boolean> {
+      query = wrapIdToQuery(query);
+      const deleted = await collection.deleteOne(query);
+      if(deleted.deletedCount > 1) {
+        throw new Error(`Removed ${deleted.deletedCount} elements with query: ${JSON.stringify(query)}. Only one is Ok.`);
+      }
+      return deleted.deletedCount == 1;
+  }
+  
+  async dbRemoveMany(collection: Collection, query: string[] | object): Promise<number> {
+      if(isEmptyArray(query)) {
+      return Promise.resolve(0);
+      }
+      query = wrapIdsToQuery(query);
+      const deleted = await collection.deleteMany(query);
+      return deleted.deletedCount;
+  }
+}

--- a/server/src/services/data_layer/mongodb.ts
+++ b/server/src/services/data_layer/mongodb.ts
@@ -1,4 +1,4 @@
-import { dbQueryWrapper } from './basedb';
+import { DbQueryWrapper } from './basedb';
 
 import { Collection, FilterQuery, ObjectID } from 'mongodb';
 import { wrapIdToMongoDbQuery, wrapIdsToMongoDbQuery, isEmptyArray } from './utils';
@@ -6,7 +6,7 @@ import { wrapIdToMongoDbQuery, wrapIdsToMongoDbQuery, isEmptyArray } from './uti
 import * as _ from 'lodash';
 
 
-export class MongoDbQueryWrapper implements dbQueryWrapper {
+export class MongoDbQueryWrapper implements DbQueryWrapper {
 
   async dbInsertOne(collection: Collection, doc: any): Promise<string> {
     // http://mongodb.github.io/node-mongodb-native/3.1/api/Collection.html#insertOne

--- a/server/src/services/data_layer/mongodb.ts
+++ b/server/src/services/data_layer/mongodb.ts
@@ -2,17 +2,18 @@ import { Collection, FilterQuery, ObjectID } from 'mongodb';
 import { wrapIdToQuery, wrapIdsToQuery, isEmptyArray } from './utils';
 
 import * as _ from 'lodash';
-import { strict } from 'assert';
 
 
 export class MongoDbAdapter {
 
   async dbInsertOne(nd: Collection, doc: object): Promise<string> {
+    // http://mongodb.github.io/node-mongodb-native/3.1/api/Collection.html#insertOne
     const newDoc = await nd.insertOne(doc);
     return newDoc.insertedId.toString();
   }
   
   async dbInsertMany(nd: Collection, docs: object[]): Promise<string[]> {
+    // http://mongodb.github.io/node-mongodb-native/3.1/api/Collection.html#insertMany
     if(docs.length === 0) {
       return Promise.resolve([]);
     }
@@ -20,20 +21,18 @@ export class MongoDbAdapter {
     return _.map(newDocs.insertedIds, (k,v) => v.toString());
   }
   
-  async dbUpdateOne(nd: Collection, query: FilterQuery<string | object>, updateQuery: object): Promise<any> {
-    // https://github.com/louischatriot/nedb#updating-documents
+  async dbUpdateOne(nd: Collection, query: FilterQuery<string | object>, updateQuery: object): Promise<void> {
+    // http://mongodb.github.io/node-mongodb-native/3.1/api/Collection.html#updateOne
     let mongodbUpdateQuery = { $set: updateQuery }
     query = wrapIdToQuery(query);
     const affected = await nd.updateOne(
       query,
-      mongodbUpdateQuery,
-  //TODO: check follow option: { returnUpdatedDocs: true },
+      mongodbUpdateQuery
     );
-    return affected.result; // return updated object
   }
   
   async dbUpdateMany(collection: Collection, query: string[] | object, updateQuery: object): Promise<void> {
-      // https://github.com/louischatriot/nedb#updating-documents
+      // http://mongodb.github.io/node-mongodb-native/3.1/api/Collection.html#updateMany
       if(isEmptyArray(query)) {
       return Promise.resolve();
       }
@@ -42,13 +41,11 @@ export class MongoDbAdapter {
       const affectedDocuments = await collection.updateMany(
           query,
           mongodbUpdateQuery
-          //add returnUpdatedDocs: true, 
       );
-      //?? return updated object
   }
   
   async dbFindOne(collection: Collection, query: FilterQuery<string | object>): Promise<any> {
-    console.log(query);
+    // http://mongodb.github.io/node-mongodb-native/3.1/api/Collection.html#findOne
     if(typeof query === 'string') {
       query = new ObjectID(query as string);
     }
@@ -58,32 +55,34 @@ export class MongoDbAdapter {
       doc._id = doc._id.toString();
     }
     return doc;
-
   }
   
   async dbFindMany(collection: Collection, query: string[] | object, sortQuery: object = {}): Promise<any[]> {
-      if(isEmptyArray(query)) {
+    // http://mongodb.github.io/node-mongodb-native/3.1/api/Collection.html#find  
+    if(isEmptyArray(query)) {
       return Promise.resolve([]);
-      }
-      query = wrapIdsToQuery(query);
-      return await collection.find(query).sort(sortQuery).toArray();
+    }
+    query = wrapIdsToQuery(query);
+    return await collection.find(query).sort(sortQuery).toArray();
   }
   
   async dbRemoveOne(collection: Collection, query: FilterQuery<string | object>): Promise<boolean> {
-      query = wrapIdToQuery(query);
-      const deleted = await collection.deleteOne(query);
-      if(deleted.deletedCount > 1) {
-        throw new Error(`Removed ${deleted.deletedCount} elements with query: ${JSON.stringify(query)}. Only one is Ok.`);
-      }
-      return deleted.deletedCount == 1;
+    // http://mongodb.github.io/node-mongodb-native/3.1/api/Collection.html#deleteOne
+    query = wrapIdToQuery(query);
+    const deleted = await collection.deleteOne(query);
+    if(deleted.deletedCount > 1) {
+      throw new Error(`Removed ${deleted.deletedCount} elements with query: ${JSON.stringify(query)}. Only one is Ok.`);
+    }
+    return deleted.deletedCount == 1;
   }
   
   async dbRemoveMany(collection: Collection, query: string[] | object): Promise<number> {
-      if(isEmptyArray(query)) {
+    // http://mongodb.github.io/node-mongodb-native/3.1/api/Collection.html#deleteMany
+    if(isEmptyArray(query)) {
       return Promise.resolve(0);
-      }
-      query = wrapIdsToQuery(query);
-      const deleted = await collection.deleteMany(query);
-      return deleted.deletedCount;
+    }
+    query = wrapIdsToQuery(query);
+    const deleted = await collection.deleteMany(query);
+    return deleted.deletedCount;
   }
 }

--- a/server/src/services/data_layer/mongodb.ts
+++ b/server/src/services/data_layer/mongodb.ts
@@ -1,10 +1,12 @@
-import { Collection, FilterQuery, ObjectID } from 'mongodb';
+import { dbQueryWrapper } from "./basedb";
+
+import { Collection, FilterQuery } from 'mongodb';
 import { wrapIdToMongoDbQuery, wrapIdsToMongoDbQuery, isEmptyArray } from './utils';
 
 import * as _ from 'lodash';
 
 
-export class MongoDbAdapter {
+export class MongoDbAdapter implements dbQueryWrapper {
 
   async dbInsertOne(nd: Collection, doc: object): Promise<string> {
     // http://mongodb.github.io/node-mongodb-native/3.1/api/Collection.html#insertOne
@@ -15,7 +17,7 @@ export class MongoDbAdapter {
   async dbInsertMany(nd: Collection, docs: object[]): Promise<string[]> {
     // http://mongodb.github.io/node-mongodb-native/3.1/api/Collection.html#insertMany
     if(docs.length === 0) {
-      return Promise.resolve([]);
+      return [];
     }
     const newDocs = await nd.insertMany(docs);
     return _.map(newDocs.insertedIds, (k,v) => v.toString());
@@ -34,7 +36,7 @@ export class MongoDbAdapter {
   async dbUpdateMany(collection: Collection, query: string[] | object, updateQuery: object): Promise<void> {
       // http://mongodb.github.io/node-mongodb-native/3.1/api/Collection.html#updateMany
       if(isEmptyArray(query)) {
-      return Promise.resolve();
+        return;
       }
       let mongodbUpdateQuery = { $set: updateQuery };
       query = wrapIdsToMongoDbQuery(query);

--- a/server/src/services/data_layer/mongodb.ts
+++ b/server/src/services/data_layer/mongodb.ts
@@ -8,26 +8,26 @@ import * as _ from 'lodash';
 
 export class MongoDbQueryWrapper implements dbQueryWrapper {
 
-  async dbInsertOne(nd: Collection, doc: object): Promise<string> {
+  async dbInsertOne(collection: Collection, doc: object): Promise<string> {
     // http://mongodb.github.io/node-mongodb-native/3.1/api/Collection.html#insertOne
-    const newDoc = await nd.insertOne(doc);
+    const newDoc = await collection.insertOne(doc);
     return newDoc.insertedId.toString();
   }
   
-  async dbInsertMany(nd: Collection, docs: object[]): Promise<string[]> {
+  async dbInsertMany(collection: Collection, docs: object[]): Promise<string[]> {
     // http://mongodb.github.io/node-mongodb-native/3.1/api/Collection.html#insertMany
     if(docs.length === 0) {
       return [];
     }
-    const newDocs = await nd.insertMany(docs);
+    const newDocs = await collection.insertMany(docs);
     return _.map(newDocs.insertedIds, (k,v) => v.toString());
   }
   
-  async dbUpdateOne(nd: Collection, query: FilterQuery<string | object>, updateQuery: object): Promise<void> {
+  async dbUpdateOne(collection: Collection, query: FilterQuery<string | object>, updateQuery: object): Promise<void> {
     // http://mongodb.github.io/node-mongodb-native/3.1/api/Collection.html#updateOne
     let mongodbUpdateQuery = { $set: updateQuery }
     query = wrapIdToMongoDbQuery(query);
-    await nd.updateOne(
+    await collection.updateOne(
       query,
       mongodbUpdateQuery
     );

--- a/server/src/services/data_layer/mongodb.ts
+++ b/server/src/services/data_layer/mongodb.ts
@@ -1,6 +1,6 @@
 import { dbQueryWrapper } from './basedb';
 
-import { Collection, FilterQuery } from 'mongodb';
+import { Collection, FilterQuery, ObjectID } from 'mongodb';
 import { wrapIdToMongoDbQuery, wrapIdsToMongoDbQuery, isEmptyArray } from './utils';
 
 import * as _ from 'lodash';
@@ -8,63 +8,93 @@ import * as _ from 'lodash';
 
 export class MongoDbQueryWrapper implements dbQueryWrapper {
 
-  async dbInsertOne(collection: Collection, doc: object): Promise<string> {
+  async dbInsertOne(collection: Collection, doc: any): Promise<string> {
     // http://mongodb.github.io/node-mongodb-native/3.1/api/Collection.html#insertOne
+
+    // TODO: move to utils
+    if(doc._id !== undefined) {
+      doc._id = new ObjectID(doc._id);
+    }
     const newDoc = await collection.insertOne(doc);
     return newDoc.insertedId.toString();
   }
-  
-  async dbInsertMany(collection: Collection, docs: object[]): Promise<string[]> {
+
+  async dbInsertMany(collection: Collection, docs: any[]): Promise<string[]> {
     // http://mongodb.github.io/node-mongodb-native/3.1/api/Collection.html#insertMany
     if(docs.length === 0) {
       return [];
     }
+
+    // TODO: move to utils
+    docs.forEach(doc => {
+      if(doc._id !== undefined) {
+        doc._id = new ObjectID(doc._id);
+      }
+    });
     const newDocs = await collection.insertMany(docs);
-    return _.map(newDocs.insertedIds, (k,v) => v.toString());
+    return _.map(newDocs.insertedIds, (id: ObjectID) => id.toString());
   }
-  
-  async dbUpdateOne(collection: Collection, query: FilterQuery<string | object>, updateQuery: object): Promise<void> {
+
+  async dbUpdateOne(collection: Collection, query: FilterQuery<string | object>, updateQuery: any): Promise<void> {
     // http://mongodb.github.io/node-mongodb-native/3.1/api/Collection.html#updateOne
+
+    // "_id" is immutable. Mongo throws an exception if updateQuery contains "_id" field.
+    if(updateQuery._id !== undefined) {
+      delete updateQuery._id;
+    }
     let mongodbUpdateQuery = { $set: updateQuery }
     query = wrapIdToMongoDbQuery(query);
+
     await collection.updateOne(
       query,
       mongodbUpdateQuery
     );
   }
-  
-  async dbUpdateMany(collection: Collection, query: string[] | object, updateQuery: object): Promise<void> {
-      // http://mongodb.github.io/node-mongodb-native/3.1/api/Collection.html#updateMany
-      if(isEmptyArray(query)) {
-        return;
-      }
-      let mongodbUpdateQuery = { $set: updateQuery };
-      query = wrapIdsToMongoDbQuery(query);
-      await collection.updateMany(
-        query,
-        mongodbUpdateQuery
-      );
+
+  async dbUpdateMany(collection: Collection, query: string[] | object, updateQuery: any): Promise<void> {
+    // http://mongodb.github.io/node-mongodb-native/3.1/api/Collection.html#updateMany
+    if(isEmptyArray(query)) {
+      return;
+    }
+    // "_id" is immutable. Mongo throws an exception if updateQuery contains "_id" field.
+    if(updateQuery._id !== undefined) {
+      delete updateQuery._id;
+    }
+    let mongodbUpdateQuery = { $set: updateQuery };
+    query = wrapIdsToMongoDbQuery(query);
+    await collection.updateMany(
+      query,
+      mongodbUpdateQuery
+    );
   }
-  
+
   async dbFindOne(collection: Collection, query: FilterQuery<string | object>): Promise<any> {
     // http://mongodb.github.io/node-mongodb-native/3.1/api/Collection.html#findOne
     query = wrapIdToMongoDbQuery(query);
     let doc = await collection.findOne(query);
+    // TODO: move to utils
     if(doc !== null) {
       doc._id = doc._id.toString();
     }
     return doc;
   }
-  
+
   async dbFindMany(collection: Collection, query: string[] | object, sortQuery: object = {}): Promise<any[]> {
-    // http://mongodb.github.io/node-mongodb-native/3.1/api/Collection.html#find  
+    // http://mongodb.github.io/node-mongodb-native/3.1/api/Collection.html#find
     if(isEmptyArray(query)) {
       return [];
     }
     query = wrapIdsToMongoDbQuery(query);
-    return await collection.find(query).sort(sortQuery).toArray();
+    const docs = await collection.find(query).sort(sortQuery).toArray();
+    // TODO: move to utils
+    docs.forEach(doc => {
+      if(doc !== null) {
+        doc._id = doc._id.toString();
+      }
+    });
+    return docs;
   }
-  
+
   async dbRemoveOne(collection: Collection, query: FilterQuery<string | object>): Promise<boolean> {
     // http://mongodb.github.io/node-mongodb-native/3.1/api/Collection.html#deleteOne
     query = wrapIdToMongoDbQuery(query);
@@ -74,7 +104,7 @@ export class MongoDbQueryWrapper implements dbQueryWrapper {
     }
     return deleted.deletedCount === 1;
   }
-  
+
   async dbRemoveMany(collection: Collection, query: string[] | object): Promise<number> {
     // http://mongodb.github.io/node-mongodb-native/3.1/api/Collection.html#deleteMany
     if(isEmptyArray(query)) {

--- a/server/src/services/data_layer/mongodb.ts
+++ b/server/src/services/data_layer/mongodb.ts
@@ -1,4 +1,4 @@
-import { dbQueryWrapper } from "./basedb";
+import { dbQueryWrapper } from './basedb';
 
 import { Collection, FilterQuery } from 'mongodb';
 import { wrapIdToMongoDbQuery, wrapIdsToMongoDbQuery, isEmptyArray } from './utils';
@@ -27,7 +27,7 @@ export class MongoDbQueryWrapper implements dbQueryWrapper {
     // http://mongodb.github.io/node-mongodb-native/3.1/api/Collection.html#updateOne
     let mongodbUpdateQuery = { $set: updateQuery }
     query = wrapIdToMongoDbQuery(query);
-    const affected = await nd.updateOne(
+    await nd.updateOne(
       query,
       mongodbUpdateQuery
     );
@@ -40,9 +40,9 @@ export class MongoDbQueryWrapper implements dbQueryWrapper {
       }
       let mongodbUpdateQuery = { $set: updateQuery };
       query = wrapIdsToMongoDbQuery(query);
-      const affectedDocuments = await collection.updateMany(
-          query,
-          mongodbUpdateQuery
+      await collection.updateMany(
+        query,
+        mongodbUpdateQuery
       );
   }
   
@@ -59,7 +59,7 @@ export class MongoDbQueryWrapper implements dbQueryWrapper {
   async dbFindMany(collection: Collection, query: string[] | object, sortQuery: object = {}): Promise<any[]> {
     // http://mongodb.github.io/node-mongodb-native/3.1/api/Collection.html#find  
     if(isEmptyArray(query)) {
-      return Promise.resolve([]);
+      return [];
     }
     query = wrapIdsToMongoDbQuery(query);
     return await collection.find(query).sort(sortQuery).toArray();
@@ -72,13 +72,13 @@ export class MongoDbQueryWrapper implements dbQueryWrapper {
     if(deleted.deletedCount > 1) {
       throw new Error(`Removed ${deleted.deletedCount} elements with query: ${JSON.stringify(query)}. Only one is Ok.`);
     }
-    return deleted.deletedCount == 1;
+    return deleted.deletedCount === 1;
   }
   
   async dbRemoveMany(collection: Collection, query: string[] | object): Promise<number> {
     // http://mongodb.github.io/node-mongodb-native/3.1/api/Collection.html#deleteMany
     if(isEmptyArray(query)) {
-      return Promise.resolve(0);
+      return 0;
     }
     query = wrapIdsToMongoDbQuery(query);
     const deleted = await collection.deleteMany(query);

--- a/server/src/services/data_layer/nedb.ts
+++ b/server/src/services/data_layer/nedb.ts
@@ -52,7 +52,7 @@ export class NeDbAdapter implements dbQueryWrapper {
     });
   }
     
-  async dbUpdateMany(nd: nedb, query: string[] | object, updateQuery: object): Promise<void> {
+  async dbUpdateMany(nd: nedb, query: string[] | object, updateQuery: object): Promise<any> {
     // https://github.com/louischatriot/nedb#updating-documents
     if(isEmptyArray(query)) {
       return;

--- a/server/src/services/data_layer/nedb.ts
+++ b/server/src/services/data_layer/nedb.ts
@@ -1,0 +1,136 @@
+import * as nedb from 'nedb';
+import { wrapIdToQuery, wrapIdsToQuery, isEmptyArray } from './utils';
+
+export class NeDbAdapter {
+  async dbInsertOne(nd: nedb, doc: object): Promise<string> {
+    return new Promise<string>((resolve, reject) => {
+      nd.insert(doc, (err, newDoc: any) => {
+        if(err) {
+          reject(err);
+        } else {
+          resolve(newDoc._id);
+        }
+      })
+    });
+  }
+    
+  async dbInsertMany(nd: nedb, docs: object[]): Promise<string[]> {
+    if(docs.length === 0) {
+      return Promise.resolve([]);
+    }
+    return new Promise<string[]>((resolve, reject) => {
+      nd.insert(docs, (err, newDocs: any[]) => {
+        if(err) {
+          reject(err);
+        } else {
+          resolve(newDocs.map(d => d._id));
+        }
+      });
+    });
+  }
+    
+  async dbUpdateOne(nd: nedb, query: string | object, updateQuery: object): Promise<any> {
+    // https://github.com/louischatriot/nedb#updating-documents
+    let nedbUpdateQuery = { $set: updateQuery }
+    query = wrapIdToQuery(query);
+    return new Promise<any>((resolve, reject) => {
+      nd.update(
+        query,
+        nedbUpdateQuery,
+        { returnUpdatedDocs: true },
+        (err: Error, numAffected: number, affectedDocument: any) => {
+          if(err) {
+            reject(err);
+          } else {
+            resolve(affectedDocument);
+          }
+        }
+      );
+    });
+  }
+    
+  async dbUpdateMany(nd: nedb, query: string[] | object, updateQuery: object): Promise<any[]> {
+    // https://github.com/louischatriot/nedb#updating-documents
+    if(isEmptyArray(query)) {
+      return Promise.resolve([]);
+    }
+    let nedbUpdateQuery = { $set: updateQuery };
+    query = wrapIdsToQuery(query);
+    return new Promise<any[]>((resolve, reject) => {
+      nd.update(
+        query,
+        nedbUpdateQuery,
+        { returnUpdatedDocs: true, multi: true },
+        (err: Error, numAffected: number, affectedDocuments: any[]) => {
+          if(err) {
+            reject(err);
+          } else {
+            resolve(affectedDocuments);
+          }
+        }
+      );
+    });
+  }
+  
+  async dbFindOne(nd: nedb, query: string | object): Promise<any> {
+    query = wrapIdToQuery(query);
+    return new Promise<any | null>((resolve, reject) => {
+      nd.findOne(query, (err, doc) => {
+        if(err) {
+          reject(err);
+        } else {
+          resolve(doc);
+        }
+      });
+    });
+  }
+  
+  async dbFindMany(nd: nedb, query: string[] | object, sortQuery: object = {}): Promise<any[]> {
+    if(isEmptyArray(query)) {
+      return Promise.resolve([]);
+    }
+    query = wrapIdsToQuery(query);
+    return new Promise<any[]>((resolve, reject) => {
+      nd.find(query).sort(sortQuery).exec((err, docs: any[]) => {
+        if(err) {
+          reject(err);
+        } else {
+          resolve(docs);
+        }
+      });
+    });
+  }
+  
+  async dbRemoveOne(nd: nedb, query: string | object): Promise<boolean> {
+    query = wrapIdToQuery(query);
+    return new Promise<boolean>((resolve, reject) => {
+      nd.remove(query, { /* options */ }, (err, numRemoved) => {
+        if(err) {
+          reject(err);
+        } else {
+          if(numRemoved > 1) {
+            throw new Error(`Removed ${numRemoved} elements with query: ${JSON.stringify(query)}. Only one is Ok.`);
+          } else {
+            resolve(numRemoved == 1);
+          }
+        }
+      });
+    });
+  }
+  
+  async dbRemoveMany(nd: nedb, query: string[] | object): Promise<number> {
+    if(isEmptyArray(query)) {
+      return Promise.resolve(0);
+    }
+    query = wrapIdsToQuery(query);
+    return new Promise<number>((resolve, reject) => {
+      nd.remove(query, { multi: true }, (err, numRemoved) => {
+        if(err) {
+          reject(err);
+        } else {
+          resolve(numRemoved);
+        }
+      });
+    });
+  }
+}

--- a/server/src/services/data_layer/nedb.ts
+++ b/server/src/services/data_layer/nedb.ts
@@ -1,10 +1,10 @@
-import { dbQueryWrapper } from './basedb';
+import { DbQueryWrapper } from './basedb';
 import { wrapIdToQuery, wrapIdsToQuery, isEmptyArray } from './utils';
 
 import * as nedb from 'nedb';
 
 
-export class NeDbQueryWrapper implements dbQueryWrapper {
+export class NeDbQueryWrapper implements DbQueryWrapper {
   async dbInsertOne(nd: nedb, doc: object): Promise<string> {
     return new Promise<string>((resolve, reject) => {
       nd.insert(doc, (err, newDoc: any) => {

--- a/server/src/services/data_layer/nedb.ts
+++ b/server/src/services/data_layer/nedb.ts
@@ -29,7 +29,7 @@ export class NeDbAdapter {
     });
   }
     
-  async dbUpdateOne(nd: nedb, query: string | object, updateQuery: object): Promise<any> {
+  async dbUpdateOne(nd: nedb, query: string | object, updateQuery: object): Promise<void> {
     // https://github.com/louischatriot/nedb#updating-documents
     let nedbUpdateQuery = { $set: updateQuery }
     query = wrapIdToQuery(query);
@@ -42,21 +42,21 @@ export class NeDbAdapter {
           if(err) {
             reject(err);
           } else {
-            resolve(affectedDocument);
+            resolve();
           }
         }
       );
     });
   }
     
-  async dbUpdateMany(nd: nedb, query: string[] | object, updateQuery: object): Promise<any[]> {
+  async dbUpdateMany(nd: nedb, query: string[] | object, updateQuery: object): Promise<void> {
     // https://github.com/louischatriot/nedb#updating-documents
     if(isEmptyArray(query)) {
       return Promise.resolve([]);
     }
     let nedbUpdateQuery = { $set: updateQuery };
     query = wrapIdsToQuery(query);
-    return new Promise<any[]>((resolve, reject) => {
+    return new Promise<void>((resolve, reject) => {
       nd.update(
         query,
         nedbUpdateQuery,
@@ -65,7 +65,7 @@ export class NeDbAdapter {
           if(err) {
             reject(err);
           } else {
-            resolve(affectedDocuments);
+            resolve();
           }
         }
       );

--- a/server/src/services/data_layer/nedb.ts
+++ b/server/src/services/data_layer/nedb.ts
@@ -1,7 +1,10 @@
-import * as nedb from 'nedb';
+import { dbQueryWrapper } from './basedb';
 import { wrapIdToQuery, wrapIdsToQuery, isEmptyArray } from './utils';
 
-export class NeDbAdapter {
+import * as nedb from 'nedb';
+
+
+export class NeDbAdapter implements dbQueryWrapper {
   async dbInsertOne(nd: nedb, doc: object): Promise<string> {
     return new Promise<string>((resolve, reject) => {
       nd.insert(doc, (err, newDoc: any) => {
@@ -52,7 +55,7 @@ export class NeDbAdapter {
   async dbUpdateMany(nd: nedb, query: string[] | object, updateQuery: object): Promise<void> {
     // https://github.com/louischatriot/nedb#updating-documents
     if(isEmptyArray(query)) {
-      return Promise.resolve([]);
+      return;
     }
     let nedbUpdateQuery = { $set: updateQuery };
     query = wrapIdsToQuery(query);

--- a/server/src/services/data_layer/nedb.ts
+++ b/server/src/services/data_layer/nedb.ts
@@ -4,7 +4,7 @@ import { wrapIdToQuery, wrapIdsToQuery, isEmptyArray } from './utils';
 import * as nedb from 'nedb';
 
 
-export class NeDbAdapter implements dbQueryWrapper {
+export class NeDbQueryWrapper implements dbQueryWrapper {
   async dbInsertOne(nd: nedb, doc: object): Promise<string> {
     return new Promise<string>((resolve, reject) => {
       nd.insert(doc, (err, newDoc: any) => {

--- a/server/src/services/data_layer/utils.ts
+++ b/server/src/services/data_layer/utils.ts
@@ -1,0 +1,20 @@
+export function wrapIdToQuery(query: string | object): object {
+  if(typeof query === 'string') {
+    return { _id: query };
+  }
+  return query;
+}
+
+export function wrapIdsToQuery(query: string[] | object): object {
+  if(Array.isArray(query)) {
+    return { _id: { $in: query } };
+  }
+  return query;
+}
+
+export function isEmptyArray(obj: any): boolean {
+  if(!Array.isArray(obj)) {
+    return false;
+  }
+  return obj.length == 0;
+}

--- a/server/src/services/data_layer/utils.ts
+++ b/server/src/services/data_layer/utils.ts
@@ -1,6 +1,6 @@
 import { ObjectID } from 'mongodb';
 
-//TODO: move to database adapter base class
+//TODO: move to dbQueryWrapper
 
 export function wrapIdToQuery(query: string | object): object {
   if(typeof query === 'string') {

--- a/server/src/services/data_layer/utils.ts
+++ b/server/src/services/data_layer/utils.ts
@@ -1,3 +1,7 @@
+import { ObjectID } from 'mongodb';
+
+//TODO: move to database adapter base class
+
 export function wrapIdToQuery(query: string | object): object {
   if(typeof query === 'string') {
     return { _id: query };
@@ -5,8 +9,23 @@ export function wrapIdToQuery(query: string | object): object {
   return query;
 }
 
+export function wrapIdToMongoDbQuery(query: string | object): object {
+  if(typeof query === 'string') {
+    return { _id: new ObjectID(query) };
+  }
+  return query;
+}
+
 export function wrapIdsToQuery(query: string[] | object): object {
   if(Array.isArray(query)) {
+    return { _id: { $in: query } };
+  }
+  return query;
+}
+
+export function wrapIdsToMongoDbQuery(query: string[] | object): object {
+  if(Array.isArray(query)) {
+    query = query.map(id => new ObjectID(id));
     return { _id: { $in: query } };
   }
   return query;

--- a/server/src/services/data_layer/utils.ts
+++ b/server/src/services/data_layer/utils.ts
@@ -23,6 +23,8 @@ export function wrapIdsToQuery(query: string[] | object): object {
   return query;
 }
 
+// mongodb uses ObjectIds to store _id
+// we should wrap ids into ObjectID to generate correct query
 export function wrapIdsToMongoDbQuery(query: string[] | object): object {
   if(Array.isArray(query)) {
     query = query.map(id => new ObjectID(id));

--- a/server/src/services/data_layer/utils.ts
+++ b/server/src/services/data_layer/utils.ts
@@ -1,6 +1,6 @@
 import { ObjectID } from 'mongodb';
 
-//TODO: move to dbQueryWrapper
+//TODO: move to DbQueryWrapper
 
 export function wrapIdToQuery(query: string | object): object {
   if(typeof query === 'string') {

--- a/server/src/services/data_service.ts
+++ b/server/src/services/data_service.ts
@@ -90,7 +90,7 @@ async function connectToDb() {
   if(config.HASTIC_DB_CONNECTION_TYPE === DBType.nedb) {
     checkDataFolders();
     const inMemoryOnly = config.HASTIC_DB_IN_MEMORY;
-    console.log('NeDB is used as storage');
+    console.log('NeDB is used as the storage');
     // TODO: it's better if models request db which we create if it`s needed
     db.set(Collection.ANALYTIC_UNITS, new nedb({ filename: config.ANALYTIC_UNITS_DATABASE_PATH, autoload: true, timestampData: true, inMemoryOnly}));
     db.set(Collection.ANALYTIC_UNIT_CACHES, new nedb({ filename: config.ANALYTIC_UNIT_CACHES_DATABASE_PATH, autoload: true, inMemoryOnly}));

--- a/server/src/services/data_service.ts
+++ b/server/src/services/data_service.ts
@@ -1,4 +1,4 @@
-import { getDbAdapter } from './data_layer';
+import { getDbAdapter, dbCollection } from './data_layer';
 import * as config from '../config';
 
 import * as nedb from 'nedb';
@@ -43,11 +43,11 @@ export type DBQ = {
   removeMany: (query: string[] | object) => Promise<number>
 }
 
-const adapter = getDbAdapter();
-const db = new Map<Collection, nedb | mongodb.Collection<any>>();
+const queryWrapper = getDbAdapter();
+const db = new Map<Collection, dbCollection>();
 let mongoClient: mongodb.MongoClient;
 
-function dbCollectionFromCollection(collection: Collection): nedb | mongodb.Collection<any> {
+function dbCollectionFromCollection(collection: Collection): dbCollection {
   let dbCollection = db.get(collection);
   if(dbCollection === undefined) {
     throw new Error('Can`t find collection ' + collection);
@@ -57,14 +57,14 @@ function dbCollectionFromCollection(collection: Collection): nedb | mongodb.Coll
 
 export function makeDBQ(collection: Collection): DBQ {
   return {
-    findOne: adapter.dbFindOne.bind(null, dbCollectionFromCollection(collection)),
-    findMany: adapter.dbFindMany.bind(null, dbCollectionFromCollection(collection)),
-    insertOne: adapter.dbInsertOne.bind(null, dbCollectionFromCollection(collection)),
-    insertMany: adapter.dbInsertMany.bind(null, dbCollectionFromCollection(collection)),
-    updateOne: adapter.dbUpdateOne.bind(null, dbCollectionFromCollection(collection)),
-    updateMany: adapter.dbUpdateMany.bind(null, dbCollectionFromCollection(collection)),
-    removeOne: adapter.dbRemoveOne.bind(null, dbCollectionFromCollection(collection)),
-    removeMany: adapter.dbRemoveMany.bind(null, dbCollectionFromCollection(collection))
+    findOne: queryWrapper.dbFindOne.bind(null, dbCollectionFromCollection(collection)),
+    findMany: queryWrapper.dbFindMany.bind(null, dbCollectionFromCollection(collection)),
+    insertOne: queryWrapper.dbInsertOne.bind(null, dbCollectionFromCollection(collection)),
+    insertMany: queryWrapper.dbInsertMany.bind(null, dbCollectionFromCollection(collection)),
+    updateOne: queryWrapper.dbUpdateOne.bind(null, dbCollectionFromCollection(collection)),
+    updateMany: queryWrapper.dbUpdateMany.bind(null, dbCollectionFromCollection(collection)),
+    removeOne: queryWrapper.dbRemoveOne.bind(null, dbCollectionFromCollection(collection)),
+    removeMany: queryWrapper.dbRemoveMany.bind(null, dbCollectionFromCollection(collection))
   }
 }
 

--- a/server/src/services/data_service.ts
+++ b/server/src/services/data_service.ts
@@ -99,7 +99,7 @@ async function connectToDb() {
     db.set(Collection.DETECTION_SPANS, new nedb({ filename: config.DETECTION_SPANS_DATABASE_PATH, autoload: true, inMemoryOnly}));
     db.set(Collection.DB_META, new nedb({ filename: config.DB_META_PATH, autoload: true, inMemoryOnly}));
   } else if(config.HASTIC_DB_CONNECTION_TYPE === DBType.mongodb) {
-    console.log('MongoDB is used as storage');
+    console.log('MongoDB is used as the storage');
     const dbConfig = config.HASTIC_DB_CONFIG;
     const uri = `mongodb://${dbConfig.user}:${dbConfig.password}@${dbConfig.url}`;
     const auth = {

--- a/server/src/services/data_service.ts
+++ b/server/src/services/data_service.ts
@@ -1,4 +1,4 @@
-import { getDbAdapter, dbCollection } from './data_layer';
+import { getDbQueryWrapper, dbCollection } from './data_layer';
 import * as config from '../config';
 
 import * as nedb from 'nedb';
@@ -43,7 +43,7 @@ export type DBQ = {
   removeMany: (query: string[] | object) => Promise<number>
 }
 
-const queryWrapper = getDbAdapter();
+const queryWrapper = getDbQueryWrapper();
 const db = new Map<Collection, dbCollection>();
 let mongoClient: mongodb.MongoClient;
 

--- a/server/src/services/data_service.ts
+++ b/server/src/services/data_service.ts
@@ -1,4 +1,4 @@
-import { getDbQueryWrapper, dbCollection } from './data_layer';
+import { getDbQueryWrapper, dbCollection, DBType } from './data_layer';
 import * as config from '../config';
 
 import * as nedb from 'nedb';
@@ -23,7 +23,7 @@ const COLLECTION_TO_NAME_MAPPING = new Map<Collection, string>([
   [Collection.THRESHOLD, 'threshold'],
   [Collection.DETECTION_SPANS, 'detection_spans'],
   [Collection.DB_META, 'db_meta']
-])
+]);
 
 export enum SortingOrder { ASCENDING = 1, DESCENDING = -1 };
 
@@ -87,10 +87,10 @@ function checkDataFolders(): void {
 }
 
 async function connectToDb() {
-  if(config.HASTIC_DB_CONNECTION_TYPE === 'nedb') {
+  if(config.HASTIC_DB_CONNECTION_TYPE === DBType.nedb) {
     checkDataFolders();
     const inMemoryOnly = config.HASTIC_DB_IN_MEMORY;
-    console.log('NeDB used as storage');
+    console.log('NeDB is used as storage');
     // TODO: it's better if models request db which we create if it`s needed
     db.set(Collection.ANALYTIC_UNITS, new nedb({ filename: config.ANALYTIC_UNITS_DATABASE_PATH, autoload: true, timestampData: true, inMemoryOnly}));
     db.set(Collection.ANALYTIC_UNIT_CACHES, new nedb({ filename: config.ANALYTIC_UNIT_CACHES_DATABASE_PATH, autoload: true, inMemoryOnly}));
@@ -98,8 +98,8 @@ async function connectToDb() {
     db.set(Collection.THRESHOLD, new nedb({ filename: config.THRESHOLD_DATABASE_PATH, autoload: true, inMemoryOnly}));
     db.set(Collection.DETECTION_SPANS, new nedb({ filename: config.DETECTION_SPANS_DATABASE_PATH, autoload: true, inMemoryOnly}));
     db.set(Collection.DB_META, new nedb({ filename: config.DB_META_PATH, autoload: true, inMemoryOnly}));
-  } else if(config.HASTIC_DB_CONNECTION_TYPE === 'mongodb') {
-    console.log('MongoDB used as storage');
+  } else if(config.HASTIC_DB_CONNECTION_TYPE === DBType.mongodb) {
+    console.log('MongoDB is used as storage');
     const dbConfig = config.HASTIC_DB_CONFIG;
     const uri = `mongodb://${dbConfig.user}:${dbConfig.password}@${dbConfig.url}`;
     const auth = {

--- a/server/src/services/data_service.ts
+++ b/server/src/services/data_service.ts
@@ -98,7 +98,7 @@ async function connectToDb() {
     db.set(Collection.THRESHOLD, new nedb({ filename: config.THRESHOLD_DATABASE_PATH, autoload: true, inMemoryOnly}));
     db.set(Collection.DETECTION_SPANS, new nedb({ filename: config.DETECTION_SPANS_DATABASE_PATH, autoload: true, inMemoryOnly}));
     db.set(Collection.DB_META, new nedb({ filename: config.DB_META_PATH, autoload: true, inMemoryOnly}));
-  } else {
+  } else if(config.HASTIC_DB_CONNECTION_TYPE === 'mongodb') {
     console.log('MongoDB used as storage');
     const dbConfig = config.HASTIC_DB_CONFIG;
     const uri = `mongodb://${dbConfig.user}:${dbConfig.password}@${dbConfig.url}`;
@@ -112,11 +112,11 @@ async function connectToDb() {
       autoReconnect: true,
       useUnifiedTopology: true,
       authMechanism: 'SCRAM-SHA-1',
-      authSource: dbConfig.db_name
+      authSource: dbConfig.dbName
     });
     try {
       const client: mongodb.MongoClient = await mongoClient.connect();
-      const hasticDb: mongodb.Db = client.db(dbConfig.db_name);
+      const hasticDb: mongodb.Db = client.db(dbConfig.dbName);
       COLLECTION_TO_NAME_MAPPING.forEach((name, collection) => {
         db.set(collection, hasticDb.collection(name));
       });
@@ -124,6 +124,10 @@ async function connectToDb() {
       console.log(`got error while connect to MongoDB ${err}`);
       throw err;
     }
+  } else {
+    throw new Error(
+      `"${config.HASTIC_DB_CONNECTION_TYPE}" HASTIC_DB_CONNECTION_TYPE is not supported. Possible values: "nedb", "mongodb"`
+    );
   }
 }
 

--- a/server/src/services/data_service.ts
+++ b/server/src/services/data_service.ts
@@ -37,8 +37,8 @@ export type DBQ = {
   findMany: (query: string[] | object, sortQuery?: object) => Promise<any[]>,
   insertOne: (document: object) => Promise<string>,
   insertMany: (documents: object[]) => Promise<string[]>,
-  updateOne: (query: string | object, updateQuery: any) => Promise<any>,
-  updateMany: (query: string[] | object, updateQuery: any) => Promise<null>,
+  updateOne: (query: string | object, updateQuery: any) => Promise<void>,
+  updateMany: (query: string[] | object, updateQuery: any) => Promise<void>,
   removeOne: (query: string) => Promise<boolean>
   removeMany: (query: string[] | object) => Promise<number>
 }


### PR DESCRIPTION
Second part of #570 

## Changes
- added factory method that returns database query wrapper
- fixed type of `updateOne` / `updateMany` operations
- add `deasync` mock for tests

## Current state
- basic functionality works, but there are errors in console
```
Error: $or must be an array
    at Object.<anonymous> (/c/Users/rodin/wsl/hastic-server/server/dist/server-dev.js:527:19)
    at Generator.next (<anonymous>)
    at fulfilled (/c/Users/rodin/wsl/hastic-server/server/dist/server-dev.js:231:32)
    at <anonymous>
    at process._tickCallback (internal/process/next_tick.js:189:7)
```

![image](https://user-images.githubusercontent.com/1989898/64620793-3451d980-d3ed-11e9-820a-ed37661fbc7d.png)
