### PR TITLE
Error: $or must be an array

### DIFF
--- a/server/src/services/data_layer/basedb.ts
+++ b/server/src/services/data_layer/basedb.ts
@@ -13,3 +13,6 @@ export interface DbQueryWrapper {
   dbRemoveOne(collection: dbCollection, query: string | object): Promise<boolean>;
   dbRemoveMany(collection: dbCollection, query: string[] | object): Promise<number>;
 }
+
+export class QueryExecutionError extends Error {
+}

--- a/server/src/services/data_layer/mongodb.ts
+++ b/server/src/services/data_layer/mongodb.ts
@@ -121,7 +121,7 @@ export class MongoDbQueryWrapper implements DbQueryWrapper {
   }
 }
 
-function convertQueryToMongoFormat(query: any): object {
+function convertQueryToMongoFormat(query: { $or?: object, $and?: object }): object {
   if(query.$or !== undefined) {
     query.$or = convertQueryFieldToMongoFormat(query.$or);
   }

--- a/server/src/services/data_layer/mongodb.ts
+++ b/server/src/services/data_layer/mongodb.ts
@@ -1,7 +1,7 @@
 import { DbQueryWrapper, QueryExecutionError } from './basedb';
 
 import { Collection, FilterQuery, ObjectID } from 'mongodb';
-import { wrapIdToMongoDbQuery, wrapIdsToMongoDbQuery, isEmptyArray, useMongoSyntax } from './utils';
+import { wrapIdToMongoDbQuery, wrapIdsToMongoDbQuery, isEmptyArray } from './utils';
 
 import * as _ from 'lodash';
 
@@ -102,7 +102,7 @@ export class MongoDbQueryWrapper implements DbQueryWrapper {
       });
       return docs;
     } catch(error) {
-      console.error(`Can't find query in collection: ${collection.namespace}`);
+      console.error(`Can't get query result for query ${JSON.stringify(query)} in collection: ${collection.namespace}`);
       throw new QueryExecutionError(`mongo query problem: ${error.message}`);
     }
   }
@@ -126,4 +126,13 @@ export class MongoDbQueryWrapper implements DbQueryWrapper {
     const deleted = await collection.deleteMany(query);
     return deleted.deletedCount;
   }
+}
+
+function useMongoSyntax(query: object): object[] {
+  let mongoQuery = [];
+  for (const key in query) {
+    const newObject = _.pick(query, key);
+    mongoQuery.push(newObject);
+  }
+  return mongoQuery;
 }

--- a/server/src/services/data_layer/mongodb.ts
+++ b/server/src/services/data_layer/mongodb.ts
@@ -121,7 +121,7 @@ export class MongoDbQueryWrapper implements DbQueryWrapper {
   }
 }
 
-function convertQueryToMongoFormat(query: { $or?: object, $and?: object }): object {
+function convertQueryToMongoFormat(query: any): object {
   if(query.$or !== undefined) {
     query.$or = convertQueryFieldToMongoFormat(query.$or);
   }

--- a/server/src/services/data_layer/mongodb.ts
+++ b/server/src/services/data_layer/mongodb.ts
@@ -86,7 +86,7 @@ export class MongoDbQueryWrapper implements DbQueryWrapper {
     }
     query = convertQueryToMongoFormat(query);
     query = wrapIdsToMongoDbQuery(query);
-    try{
+    try {
       const docs = await collection.find(query).sort(sortQuery).toArray();
       docs.forEach(doc => {
         if (doc !== null) {
@@ -96,7 +96,7 @@ export class MongoDbQueryWrapper implements DbQueryWrapper {
       return docs;
     } catch(error) {
       console.error(`Can't get query result for query ${JSON.stringify(query)} in collection: ${collection.namespace}`);
-      throw new QueryExecutionError(`mongo query problem: ${error.message}`);
+      throw new QueryExecutionError(`MongoDB query error: ${error.message}`);
     }
   }
 

--- a/server/src/services/data_layer/mongodb.ts
+++ b/server/src/services/data_layer/mongodb.ts
@@ -79,17 +79,18 @@ export class MongoDbQueryWrapper implements DbQueryWrapper {
     return doc;
   }
 
-  async dbFindMany(collection: Collection, query: string[] | object | any, sortQuery: object = {}): Promise<any[]> {
+  async dbFindMany(collection: Collection, query: any, sortQuery: object = {}): Promise<any[]> {
     // http://mongodb.github.io/node-mongodb-native/3.1/api/Collection.html#find
     if(isEmptyArray(query)) {
       return [];
     }
     if(query.$or !== undefined) {
-      let queryOrMongo = [];
-      for(var key in query.$or) {
-        queryOrMongo.push(_.pick(query.$or, key));
+      let queryOr = [];
+      for(const key in query.$or) {
+        const newObject = _.pick(query.$or, key);
+        queryOr.push(newObject);
       }
-      query.$or = queryOrMongo;
+      query.$or = queryOr;
     }
     query = wrapIdsToMongoDbQuery(query);
     const docs = await collection.find(query).sort(sortQuery).toArray();

--- a/server/src/services/data_layer/mongodb.ts
+++ b/server/src/services/data_layer/mongodb.ts
@@ -79,10 +79,17 @@ export class MongoDbQueryWrapper implements DbQueryWrapper {
     return doc;
   }
 
-  async dbFindMany(collection: Collection, query: string[] | object, sortQuery: object = {}): Promise<any[]> {
+  async dbFindMany(collection: Collection, query: string[] | object | any, sortQuery: object = {}): Promise<any[]> {
     // http://mongodb.github.io/node-mongodb-native/3.1/api/Collection.html#find
     if(isEmptyArray(query)) {
       return [];
+    }
+    if(query.$or !== undefined) {
+      let queryOrMongo = [];
+      for(var key in query.$or) {
+        queryOrMongo.push(_.pick(query.$or, key));
+      }
+      query.$or = queryOrMongo;
     }
     query = wrapIdsToMongoDbQuery(query);
     const docs = await collection.find(query).sort(sortQuery).toArray();

--- a/server/src/services/data_layer/mongodb.ts
+++ b/server/src/services/data_layer/mongodb.ts
@@ -121,11 +121,11 @@ export class MongoDbQueryWrapper implements DbQueryWrapper {
   }
 }
 
-function convertQueryToMongoFormat(query: any): any {
-  if (query.$or !== undefined) {
+function convertQueryToMongoFormat(query: any): object {
+  if(query.$or !== undefined) {
     query.$or = convertQueryFieldToMongoFormat(query.$or);
   }
-  if (query.$and !== undefined) {
+  if(query.$and !== undefined) {
     query.$and = convertQueryFieldToMongoFormat(query.$and);
   }
   return query;
@@ -133,7 +133,7 @@ function convertQueryToMongoFormat(query: any): any {
 
 function convertQueryFieldToMongoFormat(query: object): object[] {
   let mongoQuery = [];
-  for (const key in query) {
+  for(const key in query) {
     const newObject = _.pick(query, key);
     mongoQuery.push(newObject);
   }

--- a/server/src/services/data_layer/mongodb.ts
+++ b/server/src/services/data_layer/mongodb.ts
@@ -94,7 +94,6 @@ export class MongoDbQueryWrapper implements DbQueryWrapper {
     query = wrapIdsToMongoDbQuery(query);
     try{
       const docs = await collection.find(query).sort(sortQuery).toArray();
-      // TODO: move to utils
       docs.forEach(doc => {
         if (doc !== null) {
           doc._id = doc._id.toString();

--- a/server/src/services/data_layer/utils.ts
+++ b/server/src/services/data_layer/utils.ts
@@ -41,7 +41,7 @@ export function isEmptyArray(obj: any): boolean {
   return obj.length == 0;
 }
 
-export function useMongoSyntax(query: any): any {
+export function useMongoSyntax(query: object): object[] {
   let mongoQuery = [];
   for (const key in query) {
     const newObject = _.pick(query, key);

--- a/server/src/services/data_layer/utils.ts
+++ b/server/src/services/data_layer/utils.ts
@@ -1,5 +1,4 @@
 import { ObjectID } from 'mongodb';
-import * as _ from 'lodash';
 
 //TODO: move to DbQueryWrapper
 

--- a/server/src/services/data_layer/utils.ts
+++ b/server/src/services/data_layer/utils.ts
@@ -40,12 +40,3 @@ export function isEmptyArray(obj: any): boolean {
   }
   return obj.length == 0;
 }
-
-export function useMongoSyntax(query: object): object[] {
-  let mongoQuery = [];
-  for (const key in query) {
-    const newObject = _.pick(query, key);
-    mongoQuery.push(newObject);
-  }
-  return mongoQuery;
-}

--- a/server/src/services/data_layer/utils.ts
+++ b/server/src/services/data_layer/utils.ts
@@ -1,4 +1,5 @@
 import { ObjectID } from 'mongodb';
+import * as _ from 'lodash';
 
 //TODO: move to DbQueryWrapper
 
@@ -38,4 +39,13 @@ export function isEmptyArray(obj: any): boolean {
     return false;
   }
   return obj.length == 0;
+}
+
+export function useMongoSyntax(query: any): any {
+  let mongoQuery = [];
+  for (const key in query) {
+    const newObject = _.pick(query, key);
+    mongoQuery.push(newObject);
+  }
+  return mongoQuery;
 }


### PR DESCRIPTION
### Problem
There is an error in the detection process of Anomaly or Pattern Detector with MongoDB:
```
Error: $or must be an array
    at Object.<anonymous> (/mnt/c/Users/VargB/git/hastic-server/server/dist/server-dev.js:528:19)
    at Generator.next (<anonymous>)
    at fulfilled (/mnt/c/Users/VargB/git/hastic-server/server/dist/server-dev.js:232:32)
    at <anonymous>
    at process._tickCallback (internal/process/next_tick.js:188:7)
```

![image](https://user-images.githubusercontent.com/39257464/65584311-5d47a200-df89-11e9-8b9f-542478bd7e28.png)

### Reason

MongoDB and nedb have different `$or` field syntax in `find` query.

### Changes

- change `findMany` query syntax from `$or: { labeled: true, deleted: true}` to` $or [{labeled: true}, {deleted: true}]` for MongoDB