### PR TITLE
Fix node 6 build

### DIFF
--- a/server/build/webpack.614.prod.conf.js
+++ b/server/build/webpack.614.prod.conf.js
@@ -18,7 +18,9 @@ module.exports = {
         test: /\.js$/,
         use: [
           { loader: 'babel-loader' }
-        ],
+        ]
+      },
+      {
         test: /\.node$/,
         use: [
           { loader: './build/node-loader' }


### PR DESCRIPTION
`node dist/server` fails with `SyntaxError: Unexpected token function` when node 6.x is used.

The reason is that `babel-loader` is not used. `babel-loader` is not used because of wrong `modules` syntax in webpack config.

## Changes
- use the proper`modules` syntax in `webpack.614.prod.conf.js` 