### PR TITLE
Single analytic unit in webhook image #799

### DIFF
--- a/server/src/services/alert_service.ts
+++ b/server/src/services/alert_service.ts
@@ -55,7 +55,7 @@ export class Alert {
       panelId,
       ordId: ORG_ID,
       apiRendering: true,
-      showAnalyticUnit: this.analyticUnit.id
+      analyticUnitId: this.analyticUnit.id
     };
     const response = await axios.get(renderUrl, {
       params,

--- a/server/src/services/alert_service.ts
+++ b/server/src/services/alert_service.ts
@@ -50,8 +50,15 @@ export class Alert {
     const dashboardApiURL = `${this.analyticUnit.grafanaUrl}/api/dashboards/uid/${dashdoardId}`;
     const dashboardInfo: any = await axios.get(dashboardApiURL, { headers });
     const dashboardName = _.last(dashboardInfo.data.meta.url.split('/'));
-    const renderUrl = `${this.analyticUnit.grafanaUrl}/render/d-solo/${dashdoardId}/${dashboardName}?panelId=${panelId}&ordId=${ORG_ID}&api-rendering`;
+    const renderUrl = `${this.analyticUnit.grafanaUrl}/render/d-solo/${dashdoardId}/${dashboardName}`;
+    const params = {
+      panelId,
+      ordId: ORG_ID,
+      apiRendering: true,
+      showAnalyticUnit: this.analyticUnit.id
+    };
     const response = await axios.get(renderUrl, {
+      params,
       headers,
       responseType: 'arraybuffer'
     });


### PR DESCRIPTION
Closes #799 

Depends on https://github.com/hastic/hastic-grafana-app/pull/392

## Changes
- add `analyticUnitId` param to `/render` query
- rename: `api-rendering` -> `apiRendering`
- move query params to the `params` object instead of a string