### PR TITLE
bump version of node to 10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ matrix:
   include:
     - language: node_js
       node_js:
-        - "8"
+        - "10"
       env:
         - CXX=g++-4.8
       before_script:

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:8-alpine AS build
+FROM node:10-alpine AS build
 
 # tools for building zeromq
 
@@ -12,7 +12,7 @@ WORKDIR /var/www/server
 RUN npm install
 RUN npm run build
 
-FROM node:8-alpine
+FROM node:10-alpine
 
 # Note: context starts in directory above (see docker-compose file)
 COPY .git /var/www/.git


### PR DESCRIPTION
Signed-off-by: Daniel Sutton <daniel@ducksecops.uk>

Node 8 is EOL December 2019, bumped version to Node 10 as new LTS release with support until April 2021.