### PR TITLE
AnomalyCache class

### DIFF
--- a/analytics/analytics/analytic_types/cache.py
+++ b/analytics/analytics/analytic_types/cache.py
@@ -20,7 +20,7 @@ class AnomalyCache:
         self.confidence = confidence
         self.enable_bounds = enable_bounds
         if seasonality != None and seasonality < 0:
-            raise ValueError(f'{self.analytic_unit_id} got invalid seasonality {seasonality}')
+            raise ValueError(f'Can`t create AnomalyCache: got invalid seasonality {seasonality}')
         self.seasonality = seasonality
         self.segments = segments
         self.time_step = time_step

--- a/analytics/analytics/analytic_types/cache.py
+++ b/analytics/analytics/analytic_types/cache.py
@@ -22,24 +22,16 @@ class AnomalyCache:
         if seasonality != None and seasonality < 0:
             raise ValueError(f'Can`t create AnomalyCache: got invalid seasonality {seasonality}')
         self.seasonality = seasonality
-        self.segments = SerializableList(list(map(AnomalyDetectorSegment.from_json, segments))) if segments != None else []
         self.time_step = time_step
+        if segments != None:
+            anomalySegments = list(map(AnomalyDetectorSegment.from_json, segments))
+            self.segments = SerializableList(anomalySegments)
+        else:
+            self.segments = []
 
     def set_segments(self, segments: List[AnomalyDetectorSegment]):
         if len(segments) > 0:
             self.segments = SerializableList(segments)
-
-    def get_segments(self) -> Optional[List[AnomalyDetectorSegment]]:
-        if self.segments != None:
-            return list(map(AnomalyDetectorSegment.from_json, self.segments))
-        else:
-            return []
-
-    def append_segment(self, segment: AnomalyDetectorSegment):
-        if len(self.segments) == 0:
-            self.segments = SerializableList([segment.to_json()])
-        else:
-            self.segments.append(segment.to_json())
 
     def get_enabled_bounds(self) -> Bound:
         return Bound(self.enable_bounds)

--- a/analytics/analytics/analytic_types/cache.py
+++ b/analytics/analytics/analytic_types/cache.py
@@ -24,8 +24,8 @@ class AnomalyCache:
         self.seasonality = seasonality
         self.time_step = time_step
         if segments != None:
-            anomalySegments = list(map(AnomalyDetectorSegment.from_json, segments))
-            self.segments = SerializableList(anomalySegments)
+            anomaly_segments = map(AnomalyDetectorSegment.from_json, segments)
+            self.segments = SerializableList(anomaly_segments)
         else:
             self.segments = []
 
@@ -34,4 +34,5 @@ class AnomalyCache:
             self.segments = SerializableList(segments)
 
     def get_enabled_bounds(self) -> Bound:
+        #TODO: use class with to_json()
         return Bound(self.enable_bounds)

--- a/analytics/analytics/analytic_types/cache.py
+++ b/analytics/analytics/analytic_types/cache.py
@@ -11,7 +11,7 @@ class AnomalyCache:
         self,
         alpha: float,
         confidence: float,
-        enable_bounds: str = None,
+        enable_bounds: str,
         seasonality: Optional[int] = None,
         segments: Optional[List[Dict]] = None,
         time_step: Optional[int] = None,
@@ -29,17 +29,17 @@ class AnomalyCache:
         if len(segments) > 0:
             self.segments = list(map(lambda s: s.to_json(), segments))
 
-    def get_segments(self) -> List[AnomalyDetectorSegment]:
+    def get_segments(self) -> Optional[List[AnomalyDetectorSegment]]:
         if self.segments != None:
-            return map(AnomalyDetectorSegment.from_json, self.segments)
+            return list(map(AnomalyDetectorSegment.from_json, self.segments))
         else:
-            return None
+            return []
 
     def append_segment(self, segment: AnomalyDetectorSegment):
         if self.segments == None:
-            self.segment = [segment.to_json()]
+            self.segments = [segment.to_json()]
         else:
             self.segments.append(segment.to_json())
 
-    def get_enable_bounds(self) -> Bound:
+    def get_enabled_bounds(self) -> Bound:
         return Bound(self.enable_bounds)

--- a/analytics/analytics/analytic_types/cache.py
+++ b/analytics/analytics/analytic_types/cache.py
@@ -22,12 +22,12 @@ class AnomalyCache:
         if seasonality != None and seasonality < 0:
             raise ValueError(f'Can`t create AnomalyCache: got invalid seasonality {seasonality}')
         self.seasonality = seasonality
-        self.segments = segments
+        self.segments = ExtendedList(list(map(AnomalyDetectorSegment.from_json, segments))) if segments != None else []
         self.time_step = time_step
 
     def set_segments(self, segments: List[AnomalyDetectorSegment]):
         if len(segments) > 0:
-            self.segments = list(map(lambda s: s.to_json(), segments))
+            self.segments = ExtendedList(segments)
 
     def get_segments(self) -> Optional[List[AnomalyDetectorSegment]]:
         if self.segments != None:
@@ -36,10 +36,15 @@ class AnomalyCache:
             return []
 
     def append_segment(self, segment: AnomalyDetectorSegment):
-        if self.segments == None:
-            self.segments = [segment.to_json()]
+        if len(self.segments) == 0:
+            self.segments = ExtendedList[segment.to_json()]
         else:
             self.segments.append(segment.to_json())
 
     def get_enabled_bounds(self) -> Bound:
         return Bound(self.enable_bounds)
+
+
+class ExtendedList(list):
+    def to_json(self):
+        return list(map(lambda s: s.to_json(), self))

--- a/analytics/analytics/analytic_types/cache.py
+++ b/analytics/analytics/analytic_types/cache.py
@@ -22,12 +22,12 @@ class AnomalyCache:
         if seasonality != None and seasonality < 0:
             raise ValueError(f'Can`t create AnomalyCache: got invalid seasonality {seasonality}')
         self.seasonality = seasonality
-        self.segments = ExtendedList(list(map(AnomalyDetectorSegment.from_json, segments))) if segments != None else []
+        self.segments = SerializableList(list(map(AnomalyDetectorSegment.from_json, segments))) if segments != None else []
         self.time_step = time_step
 
     def set_segments(self, segments: List[AnomalyDetectorSegment]):
         if len(segments) > 0:
-            self.segments = ExtendedList(segments)
+            self.segments = SerializableList(segments)
 
     def get_segments(self) -> Optional[List[AnomalyDetectorSegment]]:
         if self.segments != None:
@@ -37,7 +37,7 @@ class AnomalyCache:
 
     def append_segment(self, segment: AnomalyDetectorSegment):
         if len(self.segments) == 0:
-            self.segments = ExtendedList[segment.to_json()]
+            self.segments = SerializableList([segment.to_json()])
         else:
             self.segments.append(segment.to_json())
 
@@ -45,6 +45,6 @@ class AnomalyCache:
         return Bound(self.enable_bounds)
 
 
-class ExtendedList(list):
+class SerializableList(list):
     def to_json(self):
         return list(map(lambda s: s.to_json(), self))

--- a/analytics/analytics/analytic_types/cache.py
+++ b/analytics/analytics/analytic_types/cache.py
@@ -1,0 +1,45 @@
+from typing import Optional, List, Dict
+
+from analytic_types.segment import AnomalyDetectorSegment
+from analytic_types.detector_typing import Bound
+
+import utils.meta
+
+@utils.meta.JSONClass
+class AnomalyCache:
+    def __init__(
+        self,
+        alpha: float,
+        confidence: float,
+        enable_bounds: str = None,
+        seasonality: Optional[int] = None,
+        segments: Optional[List[Dict]] = None,
+        time_step: Optional[int] = None,
+    ):
+        self.alpha = alpha
+        self.confidence = confidence
+        self.enable_bounds = enable_bounds
+        if seasonality != None and seasonality < 0:
+            raise ValueError(f'{self.analytic_unit_id} got invalid seasonality {seasonality}')
+        self.seasonality = seasonality
+        self.segments = segments
+        self.time_step = time_step
+
+    def set_segments(self, segments: List[AnomalyDetectorSegment]):
+        if len(segments) > 0:
+            self.segments = list(map(lambda s: s.to_json(), segments))
+
+    def get_segments(self) -> List[AnomalyDetectorSegment]:
+        if self.segments != None:
+            return map(AnomalyDetectorSegment.from_json, self.segments)
+        else:
+            return None
+
+    def append_segment(self, segment: AnomalyDetectorSegment):
+        if self.segments == None:
+            self.segment = [segment.to_json()]
+        else:
+            self.segments.append(segment.to_json())
+
+    def get_enable_bounds(self) -> Bound:
+        return Bound(self.enable_bounds)

--- a/analytics/analytics/analytic_types/cache.py
+++ b/analytics/analytics/analytic_types/cache.py
@@ -3,9 +3,9 @@ from typing import Optional, List, Dict
 from analytic_types.segment import AnomalyDetectorSegment
 from analytic_types.detector_typing import Bound
 
-import utils.meta
+from utils.meta import JSONClass, SerializableList
 
-@utils.meta.JSONClass
+@JSONClass
 class AnomalyCache:
     def __init__(
         self,
@@ -35,8 +35,3 @@ class AnomalyCache:
 
     def get_enabled_bounds(self) -> Bound:
         return Bound(self.enable_bounds)
-
-
-class SerializableList(list):
-    def to_json(self):
-        return list(map(lambda s: s.to_json(), self))

--- a/analytics/analytics/analytic_types/detector_typing.py
+++ b/analytics/analytics/analytic_types/detector_typing.py
@@ -1,9 +1,15 @@
 from analytic_types import ModelCache, TimeSeries
 from analytic_types.segment import Segment
 
+from enum import Enum
 from typing import List, Optional, Tuple
 
 import utils.meta
+
+class Bound(Enum):
+    ALL = 'ALL'
+    UPPER = 'UPPER'
+    LOWER = 'LOWER'
 
 class DetectionResult:
 

--- a/analytics/analytics/detectors/__init__.py
+++ b/analytics/analytics/detectors/__init__.py
@@ -1,4 +1,4 @@
 from detectors.detector import Detector, ProcessingDetector
 from detectors.pattern_detector import PatternDetector
 from detectors.threshold_detector import ThresholdDetector
-from detectors.anomaly_detector import AnomalyDetector, Bound
+from detectors.anomaly_detector import AnomalyDetector

--- a/analytics/analytics/detectors/anomaly_detector.py
+++ b/analytics/analytics/detectors/anomaly_detector.py
@@ -128,7 +128,7 @@ class AnomalyDetector(ProcessingDetector):
                 break
 
         seasonality = 0
-        if len(cache.segments) > 0 and cache.seasonality > 0:
+        if len(cache.segments) > 0:
             seasonality = cache.seasonality // cache.time_step
         return max(level, seasonality)
 

--- a/analytics/analytics/detectors/anomaly_detector.py
+++ b/analytics/analytics/detectors/anomaly_detector.py
@@ -28,7 +28,7 @@ class AnomalyDetector(ProcessingDetector):
     def train(self, dataframe: pd.DataFrame, payload: Union[list, dict], cache: Optional[ModelCache]) -> ModelCache:
         cache = AnomalyCache.from_json(payload)
         cache.time_step = utils.find_interval(dataframe)
-        segments = cache.get_segments()
+        segments = cache.segments
 
         if len(segments) > 0:
             seasonality = cache.seasonality
@@ -62,7 +62,7 @@ class AnomalyDetector(ProcessingDetector):
         data = dataframe['value']
 
         cache = AnomalyCache.from_json(cache)
-        segments = cache.get_segments()
+        segments = cache.segments
         enabled_bounds = cache.get_enabled_bounds()
 
         smoothed_data = utils.exponential_smoothing(data, cache.alpha)
@@ -128,7 +128,7 @@ class AnomalyDetector(ProcessingDetector):
                 break
 
         seasonality = 0
-        if cache.segments is not None and cache.seasonality > 0:
+        if len(cache.segments) > 0 and cache.seasonality > 0:
             seasonality = cache.seasonality // cache.time_step
         return max(level, seasonality)
 
@@ -145,7 +145,7 @@ class AnomalyDetector(ProcessingDetector):
     # TODO: remove duplication with detect()
     def process_data(self, dataframe: pd.DataFrame, cache: ModelCache) -> ProcessingResult:
         cache = AnomalyCache.from_json(cache)
-        segments = cache.get_segments()
+        segments = cache.segments
         enabled_bounds =  cache.get_enabled_bounds()
 
         # TODO: exponential_smoothing should return dataframe with related timestamps

--- a/analytics/analytics/detectors/anomaly_detector.py
+++ b/analytics/analytics/detectors/anomaly_detector.py
@@ -6,9 +6,10 @@ import math
 from typing import Optional, Union, List, Tuple, Generator
 
 from analytic_types import AnalyticUnitId, ModelCache
-from analytic_types.detector_typing import DetectionResult, ProcessingResult
+from analytic_types.detector_typing import DetectionResult, ProcessingResult, Bound
 from analytic_types.data_bucket import DataBucket
 from analytic_types.segment import Segment, AnomalyDetectorSegment
+from analytic_types.cache import AnomalyCache
 from detectors import Detector, ProcessingDetector
 import utils
 
@@ -17,10 +18,6 @@ MIN_DEPENDENCY_FACTOR = 0.1
 BASIC_ALPHA = 0.5
 logger = logging.getLogger('ANOMALY_DETECTOR')
 
-class Bound(Enum):
-    ALL = 'ALL'
-    UPPER = 'UPPER'
-    LOWER = 'LOWER'
 
 class AnomalyDetector(ProcessingDetector):
 
@@ -29,23 +26,13 @@ class AnomalyDetector(ProcessingDetector):
         self.bucket = DataBucket()
 
     def train(self, dataframe: pd.DataFrame, payload: Union[list, dict], cache: Optional[ModelCache]) -> ModelCache:
-        segments = payload.get('segments')
-        enable_bounds = Bound(payload.get('enableBounds') or 'ALL')
-        prepared_segments = []
-        time_step = utils.find_interval(dataframe)
+        cache_object = AnomalyCache.from_json(payload)
+        cache_object.time_step = utils.find_interval(dataframe)
 
-        new_cache = {
-            'confidence': payload['confidence'],
-            'alpha': payload['alpha'],
-            'timeStep': time_step,
-            'enableBounds': enable_bounds.value
-        }
-
-        if segments is not None:
-            seasonality = payload.get('seasonality')
-            assert seasonality is not None and seasonality > 0, \
-                f'{self.analytic_unit_id} got invalid seasonality {seasonality}'
-            parsed_segments = map(Segment.from_json, segments)
+        if cache_object.segments is not None:
+            seasonality = cache_object.seasonality
+            parsed_segments = map(Segment.from_json, cache_object.segments)
+            prepared_segments = []
 
             for segment in parsed_segments:
                 segment_len = (int(segment.to_timestamp) - int(segment.from_timestamp))
@@ -55,17 +42,17 @@ class AnomalyDetector(ProcessingDetector):
                 from_index = utils.timestamp_to_index(dataframe, pd.to_datetime(segment.from_timestamp, unit='ms'))
                 to_index = utils.timestamp_to_index(dataframe, pd.to_datetime(segment.to_timestamp, unit='ms'))
                 segment_data = dataframe[from_index : to_index]
-                prepared_segments.append({
-                    'from': segment.from_timestamp,
-                    'to': segment.to_timestamp,
-                    'data': segment_data.value.tolist()
-                })
-
-            new_cache['seasonality'] = seasonality
-            new_cache['segments'] = prepared_segments
+                prepared_segments.append(
+                    AnomalyDetectorSegment(
+                        segment.from_timestamp,
+                        segment.to_timestamp,
+                        segment_data.value.tolist()
+                    )
+                )
+            cache_object.set_segments(prepared_segments)
 
         return {
-            'cache': new_cache
+            'cache': cache_object.to_json()
         }
 
     # TODO: ModelCache -> DetectorState
@@ -74,30 +61,26 @@ class AnomalyDetector(ProcessingDetector):
             raise f'Analytic unit {self.analytic_unit_id} got empty cache'
         data = dataframe['value']
 
-        # TODO: use class for cache to avoid using string literals
-        alpha = self.get_value_from_cache(cache, 'alpha', required = True)
-        confidence = self.get_value_from_cache(cache, 'confidence', required = True)
-        segments = self.get_value_from_cache(cache, 'segments')
-        enable_bounds = Bound(self.get_value_from_cache(cache, 'enableBounds') or 'ALL')
+        cache_object = AnomalyCache.from_json(cache)
+        segments = cache_object.get_segments()
+        enable_bounds = cache_object.get_enable_bounds()
 
-        smoothed_data = utils.exponential_smoothing(data, alpha)
+        smoothed_data = utils.exponential_smoothing(data, cache_object.alpha)
 
-        lower_bound = smoothed_data - confidence
-        upper_bound = smoothed_data + confidence
+        lower_bound = smoothed_data - cache_object.confidence
+        upper_bound = smoothed_data + cache_object.confidence
 
         if segments is not None:
-            parsed_segments = map(AnomalyDetectorSegment.from_json, segments)
-
-            time_step = self.get_value_from_cache(cache, 'timeStep', required = True)
-            seasonality = self.get_value_from_cache(cache, 'seasonality', required = True)
-            assert seasonality > 0, \
-                f'{self.analytic_unit_id} got invalid seasonality {seasonality}'
-
             data_start_time = utils.convert_pd_timestamp_to_ms(dataframe['timestamp'][0])
 
-            for segment in parsed_segments:
-                seasonality_index = seasonality // time_step
-                seasonality_offset = self.get_seasonality_offset(segment.from_timestamp, seasonality, data_start_time, time_step)
+            for segment in segments:
+                seasonality_index = cache_object.seasonality // cache_object.time_step
+                seasonality_offset = self.get_seasonality_offset(
+                    segment.from_timestamp,
+                    cache_object.seasonality,
+                    data_start_time,
+                    cache_object.time_step
+                )
                 segment_data = pd.Series(segment.data)
 
                 lower_bound = self.add_season_to_data(lower_bound, segment_data, seasonality_offset, seasonality_index, Bound.LOWER)
@@ -108,7 +91,7 @@ class AnomalyDetector(ProcessingDetector):
         last_dataframe_time = dataframe.iloc[-1]['timestamp']
         last_detection_time = utils.convert_pd_timestamp_to_ms(last_dataframe_time)
 
-        return DetectionResult(cache, detected_segments, last_detection_time)
+        return DetectionResult(cache_object.to_json(), detected_segments, last_detection_time)
 
     def consume_data(self, data: pd.DataFrame, cache: Optional[ModelCache]) -> Optional[DetectionResult]:
         if cache is None:

--- a/analytics/analytics/utils/__init__.py
+++ b/analytics/analytics/utils/__init__.py
@@ -1,3 +1,4 @@
 from utils.common import *
 from utils.time import *
 from utils.dataframe import *
+from utils.meta  import *

--- a/analytics/analytics/utils/meta.py
+++ b/analytics/analytics/utils/meta.py
@@ -22,7 +22,7 @@ def is_field_private(field_name: str) -> Optional[str]:
     m = re.match(r'_[^(__)]+__', field_name)
     return m is not None
 
-def find_to_json_methods(obj):
+def serialize(obj):
     if hasattr(obj, 'to_json') == True:
         return obj.to_json()
     else:
@@ -61,7 +61,7 @@ def JSONClass(target_class):
         where all None - values and private fileds are skipped
         """
         return {
-            underscore_to_camel(k): find_to_json_methods(v) for k, v in self.__dict__.items()
+            underscore_to_camel(k): serialize(v) for k, v in self.__dict__.items()
             if v is not None and not is_field_private(k)
         }
 

--- a/analytics/analytics/utils/meta.py
+++ b/analytics/analytics/utils/meta.py
@@ -1,3 +1,4 @@
+import inspect
 from inspect import signature, Parameter
 from functools import wraps
 from typing import Optional
@@ -21,6 +22,12 @@ def underscore_to_camel(name):
 def is_field_private(field_name: str) -> Optional[str]:
     m = re.match(r'_[^(__)]+__', field_name)
     return m is not None
+
+def find_to_json_methods(obj):
+    if hasattr(obj, 'to_json') == True:
+        return obj.to_json()
+    else:
+        return obj
 
 def inited_params(target_init):
     target_params = signature(target_init).parameters.values()
@@ -55,7 +62,7 @@ def JSONClass(target_class):
         where all None - values and private fileds are skipped
         """
         return {
-            underscore_to_camel(k): v for k, v in self.__dict__.items()
+            underscore_to_camel(k): find_to_json_methods(v) for k, v in self.__dict__.items()
             if v is not None and not is_field_private(k)
         }
 

--- a/analytics/analytics/utils/meta.py
+++ b/analytics/analytics/utils/meta.py
@@ -1,4 +1,3 @@
-import inspect
 from inspect import signature, Parameter
 from functools import wraps
 from typing import Optional

--- a/analytics/analytics/utils/meta.py
+++ b/analytics/analytics/utils/meta.py
@@ -75,3 +75,7 @@ def JSONClass(target_class):
     target_class.to_json = to_json
     target_class.from_json = from_json
     return target_class
+
+class SerializableList(list):
+    def to_json(self):
+        return list(map(lambda s: s.to_json(), self))

--- a/analytics/tests/test_detectors.py
+++ b/analytics/tests/test_detectors.py
@@ -1,8 +1,8 @@
 import unittest
 import pandas as pd
 
-from detectors import pattern_detector, threshold_detector, anomaly_detector, Bound
-from analytic_types.detector_typing import DetectionResult, ProcessingResult
+from detectors import pattern_detector, threshold_detector, anomaly_detector
+from analytic_types.detector_typing import DetectionResult, ProcessingResult, Bound
 from analytic_types.segment import Segment
 from tests.test_dataset import create_dataframe, create_list_of_timestamps
 from utils import convert_pd_timestamp_to_ms

--- a/analytics/tests/test_detectors.py
+++ b/analytics/tests/test_detectors.py
@@ -186,7 +186,7 @@ class TestAnomalyDetector(unittest.TestCase):
         dataframe = create_dataframe(data)
         upper_bound = pd.Series([2, 2, 2, 2, 2, 2, 2, 2, 2, 2])
         lower_bound = pd.Series([0, 0, 0, 0, 0, 0, 0, 0, 0, 0])
-        segments = list(detector.detections_generator(dataframe, upper_bound, lower_bound, enable_bounds=Bound.ALL))
+        segments = list(detector.detections_generator(dataframe, upper_bound, lower_bound, enabled_bounds=Bound.ALL))
 
         segments_borders = list(map(lambda s: [s.from_timestamp, s.to_timestamp], segments))
         self.assertEqual(segments_borders, [[timestamps[2], timestamps[2]], [timestamps[4], timestamps[8]]])

--- a/analytics/tests/test_detectors.py
+++ b/analytics/tests/test_detectors.py
@@ -73,6 +73,7 @@ class TestAnomalyDetector(unittest.TestCase):
         cache =  {
             'confidence': 2,
             'alpha': 0.1,
+            'enableBounds': 'ALL',
             'timeStep': 1
         }
         detector = anomaly_detector.AnomalyDetector('test_id')
@@ -85,6 +86,7 @@ class TestAnomalyDetector(unittest.TestCase):
         cache =  {
             'confidence': 2,
             'alpha': 0.1,
+            'enableBounds': 'ALL',
             'timeStep': 1,
             'seasonality': 4,
             'segments': [{ 'from': 1523889000001, 'to': 1523889000002, 'data': [10] }]
@@ -103,6 +105,7 @@ class TestAnomalyDetector(unittest.TestCase):
         cache =  {
             'confidence': 2,
             'alpha': 0.1,
+            'enableBounds': 'ALL',
             'timeStep': 1
         }
         detector = anomaly_detector.AnomalyDetector('test_id')
@@ -135,6 +138,7 @@ class TestAnomalyDetector(unittest.TestCase):
         cache =  {
             'confidence': 2,
             'alpha': 0.1,
+            'enableBounds': 'ALL',
             'timeStep': 1,
             'seasonality': 5,
             'segments': [{ 'from': 1523889000001, 'to': 1523889000002,'data': [1] }]

--- a/analytics/tests/test_utils.py
+++ b/analytics/tests/test_utils.py
@@ -362,5 +362,12 @@ class TestUtils(unittest.TestCase):
                 self.assertEqual(got.from_timestamp, expected[0])
                 self.assertEqual(got.to_timestamp, expected[1])
 
+    def test_serialize(self):
+        segment_list = [Segment(100,200)]
+        serialize_list = utils.meta.SerializableList(segment_list)
+        meta_result = utils.meta.serialize(serialize_list)
+        expected_result = [{ 'from': 100, 'to': 200 }]
+        self.assertEqual(meta_result, expected_result)
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This PR adds new `AnomalyCache` class which is used in `AnomalyDetector` instead of dict.

## Changes:
 - add new `AnomalyCache` class with:
     - required fields: `alpha`, `confidence`, `enable_bounds`
     - optional fields: `seasonality`, `segments`, `time_step`
     - method `set_segments`, which sets `self.segments` wrapped in `SerializableList`
     - method `get_enabled_bound`, which returns `self.enable_bound` wrapped in `Bound`
 - uses `meta.JSONClass` decorator for `AnomalyCache` 
 - `utils.meta`:
     - add `SerializableList` class, which extends `list` with `to_json` method
     - add method `serialize` which returns `object.to_json()` if `object` has `to_json` method
     - `JSONClass.to_json` uses `serialize` method for class fields
 - replace dicts with `AnomalyCache` in `AnomalyDetector`'s methods: `train`, `detect`, `process_data`, `get_window_size`
 - rename `enable_bounds` to `enabled_bounds` in `AnomalyDetector`
 - move `enum Bound` from `AnomalyDetector` to `detector_typing`
 - fix unit tests
 - add test for `utils.meta.serialize` method