### PR TITLE
Cannot read property 'branch' of null #831

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -15,7 +15,6 @@ RUN npm run build
 FROM node:8-alpine
 
 # Note: context starts in directory above (see docker-compose file)
-COPY .git /var/www/.git
 COPY server/package.json /var/www/server/
 
 WORKDIR /var/www/server

--- a/server/build/webpack.base.conf.js
+++ b/server/build/webpack.base.conf.js
@@ -2,6 +2,8 @@ const path = require('path');
 const fs = require('fs');
 
 const webpack = require('webpack');
+const GitRevisionPlugin = require('git-revision-webpack-plugin');
+const gitRevisionPlugin = new GitRevisionPlugin();
 
 
 function resolve(p) {
@@ -23,6 +25,11 @@ module.exports = {
     minimize: false
   },
   plugins: [
+    new webpack.DefinePlugin({
+      'GIT_VERSION': JSON.stringify(gitRevisionPlugin.version()),
+      'GIT_COMMITHASH': JSON.stringify(gitRevisionPlugin.commithash()),
+      'GIT_BRANCH': JSON.stringify(gitRevisionPlugin.branch()),
+    })
   ],
   resolve: {
     extensions: [".ts", ".js"],

--- a/server/jest.config.js
+++ b/server/jest.config.js
@@ -4,7 +4,10 @@ module.exports = {
     "ts-jest": {
       "useBabelrc": true,
       "tsConfigFile": "tsconfig.jest.json"
-    }
+    },
+  "GIT_VERSION": "test_version",
+  "GIT_COMMITHASH": "test_commit_hash",
+  "GIT_BRANCH": "test_branch"
   },
   "transform": {
     "\\.ts": "ts-jest"

--- a/server/package.json
+++ b/server/package.json
@@ -41,6 +41,7 @@
     "es6-promise": "^4.2.4",
     "event-stream": "3.3.4",
     "file-loader": "^1.1.11",
+    "git-revision-webpack-plugin": "^3.0.4",
     "grafana-datasource-kit": "0.1.17",
     "jest": "^23.1.1",
     "koa": "^2.0.46",

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -9,6 +9,10 @@ import * as fs from 'fs';
 import * as os from 'os';
 
 
+declare const GIT_BRANCH: string;
+declare const GIT_COMMITHASH: string;
+declare const GIT_VERSION: string;
+
 let configFile = path.join(__dirname, '../../config.json');
 let configExists = fs.existsSync(configFile);
 
@@ -66,7 +70,11 @@ export const HASTIC_ALERTMANAGER_URL = getConfigField('HASTIC_ALERTMANAGER_URL',
 
 export const ANLYTICS_PING_INTERVAL = 500; // ms
 export const PACKAGE_VERSION = getPackageVersion();
-export const GIT_INFO = getGitInfo();
+export const GIT_INFO = {
+  branch: GIT_BRANCH,
+  commitHash: GIT_COMMITHASH,
+  version: GIT_VERSION
+};
 export const INSIDE_DOCKER = process.env.INSIDE_DOCKER !== undefined;
 export const PRODUCTION_MODE = process.env.NODE_ENV !== 'development';
 
@@ -114,32 +122,6 @@ function getPackageVersion() {
       console.log(`Can't find package file ${packageFile}`);
       return null;
     }
-  }
-}
-
-function getGitInfo() {
-  let gitRoot = path.join(__dirname, '../../.git');
-  let gitHeadFile = path.join(gitRoot, 'HEAD');
-  if(!fs.existsSync(gitHeadFile)) {
-    console.error(`Can't find git HEAD file ${gitHeadFile}`);
-    return null;
-  }
-  const ref = fs.readFileSync(gitHeadFile).toString();
-  if(ref.includes('ref')) {
-    let branchPath = ref.indexOf(':') === -1 ? ref : ref.slice(5, -1);
-    let branch = branchPath.split('/').pop();
-    const branchFilename = `${gitRoot}/${branchPath}`;
-    if(!fs.existsSync(branchFilename)) {
-      console.error(`Can't find git branch file ${branchFilename}`);
-      return null;
-    }
-    let commitHash = fs.readFileSync(branchFilename).toString().slice(0, 7);
-    return { branch, commitHash };
-  } else {
-    return {
-      branch: 'detached',
-      commitHash: ref.toString().slice(0, 7)
-    };
   }
 }
 

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -125,15 +125,22 @@ function getGitInfo() {
     return null;
   }
   const ref = fs.readFileSync(gitHeadFile).toString();
-  let branchPath = ref.indexOf(':') === -1 ? ref : ref.slice(5, -1);
-  let branch = branchPath.split('/').pop();
-  const branchFilename = `${gitRoot}/${branchPath}`;
-  if(!fs.existsSync(branchFilename)) {
-    console.error(`Can't find git branch file ${branchFilename}`);
-    return null;
+  if(ref.includes('ref')) {
+    let branchPath = ref.indexOf(':') === -1 ? ref : ref.slice(5, -1);
+    let branch = branchPath.split('/').pop();
+    const branchFilename = `${gitRoot}/${branchPath}`;
+    if(!fs.existsSync(branchFilename)) {
+      console.error(`Can't find git branch file ${branchFilename}`);
+      return null;
+    }
+    let commitHash = fs.readFileSync(branchFilename).toString().slice(0, 7);
+    return { branch, commitHash };
+  } else {
+    return {
+      branch: 'detached',
+      commitHash: ref.toString().slice(0, 7)
+    };
   }
-  let commitHash = fs.readFileSync(branchFilename).toString().slice(0, 7);
-  return { branch, commitHash };
 }
 
 function createZMQConnectionString() {


### PR DESCRIPTION
fixes #831 

Problem: when git is in the detached state (for example after checkout to tag `git checkout 0.3.8`) `.git/HEAD` file doesn't contain ref name. It leads to "Cannot read property 'branch' of null" error in the panel.

## Changes
- use `git-revision-webpack-plugin` for extracting git information and place it to config in build time