### PR TITLE
Export analytic units

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -1,7 +1,8 @@
 import { router as analyticUnitsRouter } from './routes/analytic_units_router';
 import { router as segmentsRouter } from './routes/segments_router';
 import { router as dataRouter } from './routes/data_router';
-import { router as detectionsRouter }  from './routes/detections_router';
+import { router as detectionsRouter } from './routes/detections_router';
+import { router as panelRouter } from './routes/panel_router';
 
 import * as AnalyticsController from './controllers/analytics_controller';
 
@@ -57,6 +58,7 @@ async function init() {
   rootRouter.use('/segments', segmentsRouter.routes(), segmentsRouter.allowedMethods());
   rootRouter.use('/query', dataRouter.routes(), dataRouter.allowedMethods());
   rootRouter.use('/detections', detectionsRouter.routes(), detectionsRouter.allowedMethods());
+  rootRouter.use('/panel', panelRouter.routes(), panelRouter.allowedMethods());
 
   rootRouter.get('/', async (ctx) => {
     const activeWebhooks = await AnalyticsController.getActiveWebhooks();

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -58,7 +58,7 @@ async function init() {
   rootRouter.use('/segments', segmentsRouter.routes(), segmentsRouter.allowedMethods());
   rootRouter.use('/query', dataRouter.routes(), dataRouter.allowedMethods());
   rootRouter.use('/detections', detectionsRouter.routes(), detectionsRouter.allowedMethods());
-  rootRouter.use('/panel', panelRouter.routes(), panelRouter.allowedMethods());
+  rootRouter.use('/panels', panelRouter.routes(), panelRouter.allowedMethods());
 
   rootRouter.get('/', async (ctx) => {
     const activeWebhooks = await AnalyticsController.getActiveWebhooks();

--- a/server/src/models/analytic_unit_cache_model.ts
+++ b/server/src/models/analytic_unit_cache_model.ts
@@ -8,6 +8,10 @@ const db = makeDBQ(Collection.ANALYTIC_UNIT_CACHES);
 // TODO: count milliseconds in index from dataset
 const MILLISECONDS_IN_INDEX = 60000;
 
+type FindManyQuery = {
+  _id: { $in: AnalyticUnitId[] }
+};
+
 export class AnalyticUnitCache {
   public constructor(
     public id: AnalyticUnitId,
@@ -63,6 +67,14 @@ export async function findById(id: AnalyticUnitId): Promise<AnalyticUnitCache | 
     return null;
   }
   return AnalyticUnitCache.fromObject(obj);
+}
+
+export async function findMany(query: FindManyQuery): Promise<AnalyticUnitCache[]> {
+  let caches = await db.findMany(query);
+  if(caches === null) {
+    return [];
+  }
+  return caches.map(cache => AnalyticUnitCache.fromObject(cache));
 }
 
 export async function create(id: AnalyticUnitId): Promise<AnalyticUnitId> {

--- a/server/src/models/analytic_units/analytic_unit_model.ts
+++ b/server/src/models/analytic_units/analytic_unit_model.ts
@@ -1,6 +1,11 @@
-import { AnalyticUnitId, AnalyticUnitStatus, DetectorType } from './types';
+import {
+  AnalyticUnitId, AnalyticUnitStatus, DetectorType,
+  SerializedAnalyticUnit, SerializedPanelAnalyticUnit
+} from './types';
 
 import { Metric } from 'grafana-datasource-kit';
+
+import * as _ from 'lodash';
 
 export abstract class AnalyticUnit {
 
@@ -38,7 +43,7 @@ export abstract class AnalyticUnit {
     }
   }
 
-  public toObject() {
+  public toObject(): SerializedAnalyticUnit {
     let metric;
     if(this.metric !== undefined) {
       metric = this.metric.toObject();
@@ -63,7 +68,7 @@ export abstract class AnalyticUnit {
     };
   }
 
-  public toPanelObject() {
+  public toPanelObject(): SerializedPanelAnalyticUnit {
     return {
       id: this.id,
       name: this.name,
@@ -75,6 +80,16 @@ export abstract class AnalyticUnit {
       visible: this.visible,
       collapsed: this.collapsed
     };
+  }
+
+  public toTemplate(): SerializedAnalyticUnit {
+    const obj = _.cloneDeep(this.toObject());
+
+    obj.grafanaUrl = '${GRAFANA_URL}';
+    obj.panelId = '${PANEL_ID}';
+    obj.metric.datasource.url = '${DATASOURCE_URL}';
+
+    return obj;
   }
 
   get analyticProps () {

--- a/server/src/models/analytic_units/index.ts
+++ b/server/src/models/analytic_units/index.ts
@@ -1,5 +1,8 @@
 import { createAnalyticUnitFromObject } from './utils';
-import { AnalyticUnitId, AnalyticUnitStatus, DetectorType, ANALYTIC_UNIT_TYPES } from './types';
+import {
+  AnalyticUnitId, AnalyticUnitStatus, DetectorType, ANALYTIC_UNIT_TYPES,
+  SerializedAnalyticUnit, SerializedPanelAnalyticUnit
+} from './types';
 import { AnalyticUnit } from './analytic_unit_model';
 import { PatternAnalyticUnit } from './pattern_analytic_unit_model';
 import { ThresholdAnalyticUnit, Condition } from './threshold_analytic_unit_model';
@@ -19,6 +22,7 @@ import {
 
 export {
   AnalyticUnit, PatternAnalyticUnit, ThresholdAnalyticUnit, AnomalyAnalyticUnit,
+  SerializedAnalyticUnit, SerializedPanelAnalyticUnit,
   AnalyticUnitId, AnalyticUnitStatus, Bound, DetectorType, ANALYTIC_UNIT_TYPES,
   createAnalyticUnitFromObject, Condition,
   findById, findMany,

--- a/server/src/models/analytic_units/types.ts
+++ b/server/src/models/analytic_units/types.ts
@@ -75,7 +75,7 @@ export enum DetectorType {
 };
 
 export type SerializedPanelAnalyticUnit = {
-  id: string;
+  id: AnalyticUnitId;
   name: string;
   type: string;
   alert: boolean;

--- a/server/src/models/analytic_units/types.ts
+++ b/server/src/models/analytic_units/types.ts
@@ -1,3 +1,5 @@
+import { Omit } from '../../types';
+
 import { Metric } from 'grafana-datasource-kit';
 
 
@@ -71,3 +73,25 @@ export enum DetectorType {
   ANOMALY = 'anomaly',
   THRESHOLD = 'threshold'
 };
+
+export type SerializedPanelAnalyticUnit = {
+  id: string;
+  name: string;
+  type: string;
+  alert: boolean;
+  labeledColor?: string;
+  deletedColor?: string;
+  detectorType?: DetectorType;
+  visible?: boolean;
+  collapsed?: boolean;
+}
+
+export type SerializedAnalyticUnit = Omit<SerializedPanelAnalyticUnit, 'id'> & {
+  grafanaUrl: string;
+  panelId: string;
+  metric?: Metric;
+  _id?: AnalyticUnitId;
+  lastDetectionTime?: number;
+  status?: AnalyticUnitStatus;
+  error?: string;
+}

--- a/server/src/models/analytic_units/utils.ts
+++ b/server/src/models/analytic_units/utils.ts
@@ -1,9 +1,8 @@
-import { DetectorType, ANALYTIC_UNIT_TYPES } from './types';
+import { DetectorType } from './types';
 import { AnalyticUnit } from './analytic_unit_model';
 import { PatternAnalyticUnit } from './pattern_analytic_unit_model';
 import { AnomalyAnalyticUnit } from './anomaly_analytic_unit_model';
 import { ThresholdAnalyticUnit } from './threshold_analytic_unit_model';
-
 import * as _ from 'lodash';
 
 

--- a/server/src/models/analytic_units/utils.ts
+++ b/server/src/models/analytic_units/utils.ts
@@ -3,6 +3,7 @@ import { AnalyticUnit } from './analytic_unit_model';
 import { PatternAnalyticUnit } from './pattern_analytic_unit_model';
 import { AnomalyAnalyticUnit } from './anomaly_analytic_unit_model';
 import { ThresholdAnalyticUnit } from './threshold_analytic_unit_model';
+
 import * as _ from 'lodash';
 
 

--- a/server/src/models/detection_model.ts
+++ b/server/src/models/detection_model.ts
@@ -106,6 +106,16 @@ export async function findMany(id: AnalyticUnitId, query?: FindManyQuery): Promi
   return spans.map(DetectionSpan.fromObject);
 }
 
+// TODO: maybe it could have a better name
+export async function findByAnalyticUnitIds(analyticUnitIds: AnalyticUnitId[]): Promise<DetectionSpan[]> {
+  const spans = await db.findMany({ analyticUnitId: { $in: analyticUnitIds } });
+  
+  if(spans === null) {
+    return [];
+  }
+  return spans.map(DetectionSpan.fromObject);
+}
+
 export async function getIntersectedSpans(
   analyticUnitId: AnalyticUnitId,
   from: number,

--- a/server/src/models/segment_model.ts
+++ b/server/src/models/segment_model.ts
@@ -106,6 +106,14 @@ export async function findMany(id: AnalyticUnitId, query: FindManyQuery): Promis
   return segs.map(Segment.fromObject);
 }
 
+export async function findByAnalyticUnitIds(analyticUnitIds: AnalyticUnitId[]): Promise<any[]> {
+  const segments = await db.findMany({ analyticUnitId: { $in: analyticUnitIds } });
+  
+  if(segments === null) {
+    return [];
+  }
+  return segments.map(Segment.fromObject);
+}
 
 /**
  * If `from` and `to` are defined: @returns segments intersected with `[from; to]`

--- a/server/src/routes/analytic_units_router.ts
+++ b/server/src/routes/analytic_units_router.ts
@@ -28,7 +28,7 @@ async function getStatus(ctx: Router.IRouterContext) {
   }
 }
 
-async function getJson(ctx: Router.IRouterContext) {
+async function getPanelTemplate(ctx: Router.IRouterContext) {
   let panelId = ctx.request.query.panelId;
   if(panelId === undefined) {
     throw new Error('Cannot export analytic units with undefined panelId');
@@ -160,7 +160,7 @@ export var router = new Router();
 router.get('/units', getUnits);
 router.get('/status', getStatus);
 router.get('/types', getTypes);
-router.get('/json', getJson);
+router.get('/panelTemplate', getPanelTemplate);
 router.patch('/metric', updateMetric);
 router.patch('/alert', updateAlert);
 

--- a/server/src/routes/analytic_units_router.ts
+++ b/server/src/routes/analytic_units_router.ts
@@ -2,7 +2,6 @@ import * as AnalyticsController from '../controllers/analytics_controller';
 import * as AnalyticUnit from '../models/analytic_units';
 
 import { saveAnalyticUnitFromObject } from '../controllers/analytics_controller';
-import { exportAnalyticUnits } from '../services/export_service';
 
 import * as Router from 'koa-router';
 import * as _ from 'lodash';
@@ -26,17 +25,6 @@ async function getStatus(ctx: Router.IRouterContext) {
   if(analyticUnit.status === AnalyticUnit.AnalyticUnitStatus.FAILED) {
     ctx.response.body.errorMessage = analyticUnit.error;
   }
-}
-
-async function getPanelTemplate(ctx: Router.IRouterContext) {
-  let panelId = ctx.request.query.panelId;
-  if(panelId === undefined) {
-    throw new Error('Cannot export analytic units with undefined panelId');
-  }
-
-  const json = await exportAnalyticUnits(panelId);
-
-  ctx.response.body = json;
 }
 
 async function getUnits(ctx: Router.IRouterContext) {
@@ -160,7 +148,6 @@ export var router = new Router();
 router.get('/units', getUnits);
 router.get('/status', getStatus);
 router.get('/types', getTypes);
-router.get('/panelTemplate', getPanelTemplate);
 router.patch('/metric', updateMetric);
 router.patch('/alert', updateAlert);
 

--- a/server/src/routes/analytic_units_router.ts
+++ b/server/src/routes/analytic_units_router.ts
@@ -2,6 +2,7 @@ import * as AnalyticsController from '../controllers/analytics_controller';
 import * as AnalyticUnit from '../models/analytic_units';
 
 import { saveAnalyticUnitFromObject } from '../controllers/analytics_controller';
+import { exportAnalyticUnits } from '../services/export_service';
 
 import * as Router from 'koa-router';
 import * as _ from 'lodash';
@@ -25,6 +26,17 @@ async function getStatus(ctx: Router.IRouterContext) {
   if(analyticUnit.status === AnalyticUnit.AnalyticUnitStatus.FAILED) {
     ctx.response.body.errorMessage = analyticUnit.error;
   }
+}
+
+async function getJson(ctx: Router.IRouterContext) {
+  let panelId = ctx.request.query.panelId;
+  if(panelId === undefined) {
+    throw new Error('Cannot export analytic units with undefined panelId');
+  }
+
+  const json = await exportAnalyticUnits(panelId);
+
+  ctx.response.body = json;
 }
 
 async function getUnits(ctx: Router.IRouterContext) {
@@ -148,6 +160,7 @@ export var router = new Router();
 router.get('/units', getUnits);
 router.get('/status', getStatus);
 router.get('/types', getTypes);
+router.get('/json', getJson);
 router.patch('/metric', updateMetric);
 router.patch('/alert', updateAlert);
 

--- a/server/src/routes/panel_router.ts
+++ b/server/src/routes/panel_router.ts
@@ -1,0 +1,18 @@
+import { exportPanel } from '../services/export_service';
+
+import * as Router from 'koa-router';
+
+async function getPanelTemplate(ctx: Router.IRouterContext) {
+  let panelId = ctx.request.query.panelId;
+  if(panelId === undefined) {
+    throw new Error('Cannot export analytic units with undefined panelId');
+  }
+
+  const json = await exportPanel(panelId);
+
+  ctx.response.body = json;
+}
+
+export var router = new Router();
+
+router.get('/template', getPanelTemplate);

--- a/server/src/routes/panel_router.ts
+++ b/server/src/routes/panel_router.ts
@@ -2,6 +2,7 @@ import { exportPanel } from '../services/export_service';
 
 import * as Router from 'koa-router';
 
+
 async function getPanelTemplate(ctx: Router.IRouterContext) {
   let panelId = ctx.request.query.panelId;
   if(panelId === undefined) {
@@ -9,7 +10,6 @@ async function getPanelTemplate(ctx: Router.IRouterContext) {
   }
 
   const json = await exportPanel(panelId);
-
   ctx.response.body = json;
 }
 

--- a/server/src/services/export_service.ts
+++ b/server/src/services/export_service.ts
@@ -1,0 +1,30 @@
+import * as AnalyticUnit from '../models/analytic_units';
+import * as AnalyticUnitCache from '../models/analytic_unit_cache_model';
+import * as DetectionSpan from '../models/detection_model';
+import * as Segment from '../models/segment_model';
+
+
+export async function exportAnalyticUnits(panelId: string): Promise<{
+  analyticUnitTemplates: any[],
+  caches: AnalyticUnitCache.AnalyticUnitCache[],
+  detectionSpans: DetectionSpan.DetectionSpan[],
+  segments: Segment.Segment[]
+}> {
+  const analyticUnits = await AnalyticUnit.findMany({ panelId });
+  const analyticUnitIds = analyticUnits.map(analyticUnit => analyticUnit.id);
+
+  let analyticUnitTemplates = analyticUnits.map(analyticUnit => analyticUnit.toTemplate());
+
+  const [caches, detectionSpans, segments] = await Promise.all([
+    AnalyticUnitCache.findMany({ _id: { $in: analyticUnitIds } }),
+    DetectionSpan.findByAnalyticUnitIds(analyticUnitIds),
+    Segment.findByAnalyticUnitIds(analyticUnitIds)
+  ]);
+
+  return {
+    analyticUnitTemplates,
+    caches,
+    detectionSpans,
+    segments
+  };
+}

--- a/server/src/services/export_service.ts
+++ b/server/src/services/export_service.ts
@@ -12,8 +12,7 @@ export async function exportPanel(panelId: string): Promise<{
 }> {
   const analyticUnits = await AnalyticUnit.findMany({ panelId });
   const analyticUnitIds = analyticUnits.map(analyticUnit => analyticUnit.id);
-
-  let analyticUnitTemplates = analyticUnits.map(analyticUnit => analyticUnit.toTemplate());
+  const analyticUnitTemplates = analyticUnits.map(analyticUnit => analyticUnit.toTemplate());
 
   const [caches, detectionSpans, segments] = await Promise.all([
     AnalyticUnitCache.findMany({ _id: { $in: analyticUnitIds } }),

--- a/server/src/services/export_service.ts
+++ b/server/src/services/export_service.ts
@@ -4,7 +4,7 @@ import * as DetectionSpan from '../models/detection_model';
 import * as Segment from '../models/segment_model';
 
 
-export async function exportAnalyticUnits(panelId: string): Promise<{
+export async function exportPanel(panelId: string): Promise<{
   analyticUnitTemplates: any[],
   caches: AnalyticUnitCache.AnalyticUnitCache[],
   detectionSpans: DetectionSpan.DetectionSpan[],

--- a/server/src/types.ts
+++ b/server/src/types.ts
@@ -1,0 +1,7 @@
+// We should remove Omit definition when we'll be updating TypeScript
+// It was introduced in TS v3.5.1:
+// https://devblogs.microsoft.com/typescript/announcing-typescript-3-5/#the-omit-helper-type
+/**
+ * Construct a type with the properties of T except for those in type K.
+*/
+export type Omit<T, K extends string | number | symbol> = { [P in Exclude<keyof T, K>]: T[P]; }


### PR DESCRIPTION
This PR partially implements #830: adds an endpoint for exporting analytic units.

## Changes
- new `GET /panels/template` endpoint which returns:
  - analytic unit templates (analytic units with some fields changed to variables)
  - analytic unit caches
  - segments
  - detection spans
- new types for serialized analytic units
- `findMany` method for AnalyticUnitCache
- `findByAnalyticUnitIds` method for DetectionSpans and Segments

## Notes
We use TypeScript v2.6.8 which lacks ["Omit" type](https://devblogs.microsoft.com/typescript/announcing-typescript-3-5/#the-omit-helper-type) from TS 3.5.1. This PR adds this type to `server/src/types.ts`, we can remove it when we'll update TS.