### PR TITLE
Import analytic units

### DIFF
--- a/server/src/models/analytic_unit_cache_model.ts
+++ b/server/src/models/analytic_unit_cache_model.ts
@@ -82,6 +82,11 @@ export async function create(id: AnalyticUnitId): Promise<AnalyticUnitId> {
   return db.insertOne(cache.toObject());
 }
 
+// TODO: SerializedCache type
+export async function insertMany(caches: any[]): Promise<AnalyticUnitId[]> {
+  return db.insertMany(caches);
+}
+
 export async function setData(id: AnalyticUnitId, data: any) {
   return db.updateOne(id, { data });
 }

--- a/server/src/models/analytic_units/db.ts
+++ b/server/src/models/analytic_units/db.ts
@@ -1,6 +1,6 @@
 import { createAnalyticUnitFromObject } from './utils';
 import { AnalyticUnit } from './analytic_unit_model';
-import { AnalyticUnitId, FindManyQuery } from './types';
+import { AnalyticUnitId, FindManyQuery, SerializedAnalyticUnit } from './types';
 import { Collection, makeDBQ, SortingOrder } from '../../services/data_service';
 
 import { Metric } from 'grafana-datasource-kit';
@@ -39,6 +39,10 @@ export async function findMany(query: FindManyQuery): Promise<AnalyticUnit[]> {
 export async function create(unit: AnalyticUnit): Promise<AnalyticUnitId> {
   let obj = unit.toObject();
   return db.insertOne(obj);
+}
+
+export async function insertMany(analyticUnits: SerializedAnalyticUnit[]): Promise<AnalyticUnitId[]> {
+  return db.insertMany(analyticUnits);
 }
 
 export async function remove(id: AnalyticUnitId): Promise<void> {

--- a/server/src/models/analytic_units/index.ts
+++ b/server/src/models/analytic_units/index.ts
@@ -13,6 +13,7 @@ import {
   create,
   remove,
   update,
+  insertMany,
   setStatus,
   setDetectionTime,
   setAlert,
@@ -26,6 +27,6 @@ export {
   AnalyticUnitId, AnalyticUnitStatus, Bound, DetectorType, ANALYTIC_UNIT_TYPES,
   createAnalyticUnitFromObject, Condition,
   findById, findMany,
-  create, remove, update,
+  create, remove, update, insertMany,
   setStatus, setDetectionTime, setAlert, setMetric
 };

--- a/server/src/models/detection_model.ts
+++ b/server/src/models/detection_model.ts
@@ -109,7 +109,7 @@ export async function findMany(id: AnalyticUnitId, query?: FindManyQuery): Promi
 // TODO: maybe it could have a better name
 export async function findByAnalyticUnitIds(analyticUnitIds: AnalyticUnitId[]): Promise<DetectionSpan[]> {
   const spans = await db.findMany({ analyticUnitId: { $in: analyticUnitIds } });
-  
+
   if(spans === null) {
     return [];
   }
@@ -160,6 +160,11 @@ export async function insertSpan(span: DetectionSpan): Promise<SpanId> {
   spanToInsert = new DetectionSpan(span.analyticUnitId, from, to, span.status).toObject();
 
   return db.insertOne(spanToInsert);
+}
+
+// TODO: SerializedDetectionSpan type
+export async function insertMany(detectionSpans: any[]): Promise<SpanId[]> {
+  return db.insertMany(detectionSpans);
 }
 
 export function clearSpans(analyticUnitId: AnalyticUnitId) {

--- a/server/src/models/panel_model.ts
+++ b/server/src/models/panel_model.ts
@@ -1,0 +1,11 @@
+import * as AnalyticUnitCache from '../models/analytic_unit_cache_model';
+import * as DetectionSpan from '../models/detection_model';
+import * as Segment from '../models/segment_model';
+
+export type PanelTemplate = {
+  // TODO: not any
+  analyticUnitTemplates: any[],
+  caches: AnalyticUnitCache.AnalyticUnitCache[],
+  detectionSpans: DetectionSpan.DetectionSpan[],
+  segments: Segment.Segment[]
+}

--- a/server/src/models/panel_model.ts
+++ b/server/src/models/panel_model.ts
@@ -1,11 +1,17 @@
+import * as AnalyticUnit from './analytic_units';
 import * as AnalyticUnitCache from '../models/analytic_unit_cache_model';
 import * as DetectionSpan from '../models/detection_model';
 import * as Segment from '../models/segment_model';
 
 export type PanelTemplate = {
-  // TODO: not any
-  analyticUnitTemplates: any[],
+  analyticUnitTemplates: AnalyticUnit.SerializedAnalyticUnit[],
   caches: AnalyticUnitCache.AnalyticUnitCache[],
   detectionSpans: DetectionSpan.DetectionSpan[],
   segments: Segment.Segment[]
 }
+
+export type TemplateVariables = {
+  grafanaUrl: string,
+  panelId: string,
+  datasourceUrl: string
+};

--- a/server/src/models/panel_model.ts
+++ b/server/src/models/panel_model.ts
@@ -4,7 +4,7 @@ import * as DetectionSpan from '../models/detection_model';
 import * as Segment from '../models/segment_model';
 
 export type PanelTemplate = {
-  analyticUnitTemplates: AnalyticUnit.SerializedAnalyticUnit[],
+  analyticUnits: AnalyticUnit.SerializedAnalyticUnit[],
   caches: AnalyticUnitCache.AnalyticUnitCache[],
   detectionSpans: DetectionSpan.DetectionSpan[],
   segments: Segment.Segment[]

--- a/server/src/models/segment_model.ts
+++ b/server/src/models/segment_model.ts
@@ -232,6 +232,11 @@ export async function mergeAndInsertSegments(segments: Segment[]): Promise<{
   };
 }
 
+// TODO: SerializedSegment type
+export async function insertMany(segments: any[]): Promise<SegmentId[]> {
+  return db.insertMany(segments);
+}
+
 export async function setSegmentsDeleted(ids: SegmentId[]) {
   return db.updateMany(ids, { deleted: true, labeled: false });
 }

--- a/server/src/routes/panel_router.ts
+++ b/server/src/routes/panel_router.ts
@@ -21,8 +21,8 @@ async function importPanelTemplate(ctx: Router.IRouterContext) {
   };
 
   // TODO: move to model
-  if(panelTemplate.analyticUnitTemplates === undefined) {
-    throw new Error('Cannot import analytic units with undefined analyticUnitTemplates');
+  if(panelTemplate.analyticUnits === undefined) {
+    throw new Error('Cannot import analytic units with undefined analyticUnits');
   }
   if(panelTemplate.caches === undefined) {
     throw new Error('Cannot import analytic units with undefined caches');

--- a/server/src/routes/panel_router.ts
+++ b/server/src/routes/panel_router.ts
@@ -1,18 +1,41 @@
-import { exportPanel } from '../services/export_service';
+import { PanelTemplate } from '../models/panel_model';
+import { exportPanel, importPanel } from '../services/export_service';
 
 import * as Router from 'koa-router';
 
 
-async function getPanelTemplate(ctx: Router.IRouterContext) {
+async function exportPanelTemplate(ctx: Router.IRouterContext) {
   let panelId = ctx.request.query.panelId;
   if(panelId === undefined) {
     throw new Error('Cannot export analytic units with undefined panelId');
   }
 
-  const json = await exportPanel(panelId);
-  ctx.response.body = json;
+  const panelTemplate = await exportPanel(panelId);
+  ctx.response.body = panelTemplate;
+} 
+
+async function importPanelTemplate(ctx: Router.IRouterContext) {
+  const panelTemplate = ctx.request.body as PanelTemplate;
+
+  // TODO: move to model
+  if(panelTemplate.analyticUnitTemplates === undefined) {
+    throw new Error('Cannot import analytic units with undefined analyticUnitTemplates');
+  }
+  if(panelTemplate.caches === undefined) {
+    throw new Error('Cannot import analytic units with undefined caches');
+  }
+  if(panelTemplate.detectionSpans === undefined) {
+    throw new Error('Cannot import analytic units with undefined detectionSpans');
+  }
+  if(panelTemplate.segments === undefined) {
+    throw new Error('Cannot import analytic units with undefined segments');
+  }
+
+  await importPanel(panelTemplate);
+  ctx.response.status = 200;
 }
 
 export var router = new Router();
 
-router.get('/template', getPanelTemplate);
+router.get('/template', exportPanelTemplate);
+router.post('/template', importPanelTemplate);

--- a/server/src/routes/panel_router.ts
+++ b/server/src/routes/panel_router.ts
@@ -1,4 +1,4 @@
-import { PanelTemplate } from '../models/panel_model';
+import { PanelTemplate, TemplateVariables } from '../models/panel_model';
 import { exportPanel, importPanel } from '../services/export_service';
 
 import * as Router from 'koa-router';
@@ -15,7 +15,10 @@ async function exportPanelTemplate(ctx: Router.IRouterContext) {
 } 
 
 async function importPanelTemplate(ctx: Router.IRouterContext) {
-  const panelTemplate = ctx.request.body as PanelTemplate;
+  const { panelTemplate, templateVariables } = ctx.request.body as {
+    panelTemplate: PanelTemplate, 
+    templateVariables: TemplateVariables
+  };
 
   // TODO: move to model
   if(panelTemplate.analyticUnitTemplates === undefined) {
@@ -31,7 +34,17 @@ async function importPanelTemplate(ctx: Router.IRouterContext) {
     throw new Error('Cannot import analytic units with undefined segments');
   }
 
-  await importPanel(panelTemplate);
+  if(templateVariables.grafanaUrl === undefined) {
+    throw new Error('Cannot make analytic unit from template with undefined grafanaUrl');
+  }
+  if(templateVariables.panelId === undefined) {
+    throw new Error('Cannot make analytic unit from template with undefined panelId');
+  }
+  if(templateVariables.datasourceUrl === undefined) {
+    throw new Error('Cannot make analytic unit from template with undefined datasourceUrl');
+  }
+
+  await importPanel(panelTemplate, templateVariables);
   ctx.response.status = 200;
 }
 

--- a/server/src/services/export_service.ts
+++ b/server/src/services/export_service.ts
@@ -1,15 +1,12 @@
+import { PanelTemplate } from '../models/panel_model';
+
 import * as AnalyticUnit from '../models/analytic_units';
 import * as AnalyticUnitCache from '../models/analytic_unit_cache_model';
 import * as DetectionSpan from '../models/detection_model';
 import * as Segment from '../models/segment_model';
 
 
-export async function exportPanel(panelId: string): Promise<{
-  analyticUnitTemplates: any[],
-  caches: AnalyticUnitCache.AnalyticUnitCache[],
-  detectionSpans: DetectionSpan.DetectionSpan[],
-  segments: Segment.Segment[]
-}> {
+export async function exportPanel(panelId: string): Promise<PanelTemplate> {
   const analyticUnits = await AnalyticUnit.findMany({ panelId });
   const analyticUnitIds = analyticUnits.map(analyticUnit => analyticUnit.id);
   const analyticUnitTemplates = analyticUnits.map(analyticUnit => analyticUnit.toTemplate());
@@ -26,4 +23,8 @@ export async function exportPanel(panelId: string): Promise<{
     detectionSpans,
     segments
   };
+}
+
+export async function importPanel(panelTemplate: PanelTemplate): Promise<void> {
+  // TODO: insert into db
 }

--- a/server/src/services/export_service.ts
+++ b/server/src/services/export_service.ts
@@ -1,4 +1,4 @@
-import { PanelTemplate } from '../models/panel_model';
+import { PanelTemplate, TemplateVariables } from '../models/panel_model';
 
 import * as AnalyticUnit from '../models/analytic_units';
 import * as AnalyticUnitCache from '../models/analytic_unit_cache_model';
@@ -25,6 +25,17 @@ export async function exportPanel(panelId: string): Promise<PanelTemplate> {
   };
 }
 
-export async function importPanel(panelTemplate: PanelTemplate): Promise<void> {
-  // TODO: insert into db
+export async function importPanel(
+  panelTemplate: PanelTemplate,
+  variables: TemplateVariables
+): Promise<void> {
+  panelTemplate.analyticUnitTemplates.forEach(analyticUnit => {
+    analyticUnit.grafanaUrl = variables.grafanaUrl;
+    analyticUnit.panelId = variables.panelId;
+    analyticUnit.metric.datasource.url = variables.datasourceUrl;
+  });
+  await AnalyticUnit.insertMany(panelTemplate.analyticUnitTemplates);
+  await AnalyticUnitCache.insertMany(panelTemplate.caches);
+  await Segment.insertMany(panelTemplate.segments);
+  await DetectionSpan.insertMany(panelTemplate.detectionSpans);
 }

--- a/server/src/services/export_service.ts
+++ b/server/src/services/export_service.ts
@@ -18,7 +18,7 @@ export async function exportPanel(panelId: string): Promise<PanelTemplate> {
   ]);
 
   return {
-    analyticUnitTemplates,
+    analyticUnits: analyticUnitTemplates,
     caches,
     detectionSpans,
     segments
@@ -29,12 +29,12 @@ export async function importPanel(
   panelTemplate: PanelTemplate,
   variables: TemplateVariables
 ): Promise<void> {
-  panelTemplate.analyticUnitTemplates.forEach(analyticUnit => {
+  panelTemplate.analyticUnits.forEach(analyticUnit => {
     analyticUnit.grafanaUrl = variables.grafanaUrl;
     analyticUnit.panelId = variables.panelId;
     analyticUnit.metric.datasource.url = variables.datasourceUrl;
   });
-  await AnalyticUnit.insertMany(panelTemplate.analyticUnitTemplates);
+  await AnalyticUnit.insertMany(panelTemplate.analyticUnits);
   await AnalyticUnitCache.insertMany(panelTemplate.caches);
   await Segment.insertMany(panelTemplate.segments);
   await DetectionSpan.insertMany(panelTemplate.detectionSpans);


### PR DESCRIPTION
This PR adds `POST /panels/template` endpoint for importing analytic units with cache / segments / detection spans.

## Changes:
- new `POST /panels/template` endpoint
- rename `analyticUnitTemplates` to `analyticUnits`
- new `insertMany` methods for analytic units / caches / segments / detection spans

## Known issues:
- it would be useful to change IDs in the export process
- no types for serialized cache / segment / detection span