### PR TITLE
Refactor get_bounds_for_segment method

### DIFF
--- a/analytics/analytics/detectors/anomaly_detector.py
+++ b/analytics/analytics/detectors/anomaly_detector.py
@@ -196,17 +196,17 @@ class AnomalyDetector(ProcessingDetector):
                 continue
             if (idx - offset) % seasonality == 0:
                 if bound_type == Bound.UPPER:
-                    upper_segment_bound = self.get_bound_for_segment(segment, Bound.UPPER)
+                    upper_segment_bound = self.get_segment_bound(segment, Bound.UPPER)
                     data = data.add(pd.Series(upper_segment_bound.values, index = segment.index + idx), fill_value = 0)
                 elif bound_type == Bound.LOWER:
-                    lower_segment_bound = self.get_bound_for_segment(segment, Bound.LOWER)
+                    lower_segment_bound = self.get_segment_bound(segment, Bound.LOWER)
                     data = data.add(pd.Series(lower_segment_bound.values * -1, index = segment.index + idx), fill_value = 0)
                 else:
                     raise ValueError(f'unknown bound type: {bound_type.value}')
 
         return data[:len_smoothed_data]
 
-    def get_bound_for_segment(self, segment: pd.Series, bound: Bound) -> pd.Series:
+    def get_segment_bound(self, segment: pd.Series, bound: Bound) -> pd.Series:
         '''
         segment is divided by the median to determine its top or bottom part
         the part is smoothed and raised above the segment or put down below the segment

--- a/analytics/analytics/detectors/anomaly_detector.py
+++ b/analytics/analytics/detectors/anomaly_detector.py
@@ -209,7 +209,7 @@ class AnomalyDetector(ProcessingDetector):
     def get_bound_for_segment(self, segment: pd.Series, bound: Bound) -> pd.Series:
         '''
         segment is divided by the median to determine its top or bottom part
-        part is smoothed and raised above the segment or down under the segment
+        the part is smoothed and raised above the segment or put down below the segment
         '''
         if len(segment) < 2:
             return segment

--- a/analytics/tests/test_detectors.py
+++ b/analytics/tests/test_detectors.py
@@ -211,7 +211,7 @@ class TestAnomalyDetector(unittest.TestCase):
         result = [{ 'from': 1523889000010, 'to': 1523889000010 }]
         self.assertEqual(result, detected_segments)
 
-    def test_get_bound_for_segment(self):
+    def test_get_segment_bound(self):
         detector = anomaly_detector.AnomalyDetector('test_id')
         peak_segment = pd.Series([1,2,3,4,3,2,1])
         trough_segment = pd.Series([4,3,2,1,2,3,4])
@@ -223,10 +223,10 @@ class TestAnomalyDetector(unittest.TestCase):
             'max_value': 3.5,
             'min_value': 2.75
         }
-        peak_detector_result_upper = detector.get_bound_for_segment(peak_segment, Bound.UPPER)
-        peak_detector_result_lower = detector.get_bound_for_segment(peak_segment, Bound.LOWER)
-        trough_detector_result_upper = detector.get_bound_for_segment(trough_segment, Bound.UPPER)
-        trough_detector_result_lower = detector.get_bound_for_segment(trough_segment, Bound.LOWER)
+        peak_detector_result_upper = detector.get_segment_bound(peak_segment, Bound.UPPER)
+        peak_detector_result_lower = detector.get_segment_bound(peak_segment, Bound.LOWER)
+        trough_detector_result_upper = detector.get_segment_bound(trough_segment, Bound.UPPER)
+        trough_detector_result_lower = detector.get_segment_bound(trough_segment, Bound.LOWER)
 
         self.assertGreaterEqual(
             max(peak_detector_result_upper),
@@ -245,14 +245,14 @@ class TestAnomalyDetector(unittest.TestCase):
             expected_trough_segment_results['min_value']
         )
 
-    def test_get_bound_for_segment_corner_cases(self):
+    def test_get_segment_bound_corner_cases(self):
         detector = anomaly_detector.AnomalyDetector('test_id')
         empty_segment = pd.Series([])
         same_values_segment = pd.Series([2,2,2,2,2,2])
-        empty_detector_result_upper = detector.get_bound_for_segment(empty_segment, Bound.UPPER)
-        empty_detector_result_lower = detector.get_bound_for_segment(empty_segment, Bound.LOWER)
-        same_values_detector_result_upper = detector.get_bound_for_segment(same_values_segment, Bound.UPPER)
-        same_values_detector_result_lower = detector.get_bound_for_segment(same_values_segment, Bound.LOWER)
+        empty_detector_result_upper = detector.get_segment_bound(empty_segment, Bound.UPPER)
+        empty_detector_result_lower = detector.get_segment_bound(empty_segment, Bound.LOWER)
+        same_values_detector_result_upper = detector.get_segment_bound(same_values_segment, Bound.UPPER)
+        same_values_detector_result_lower = detector.get_segment_bound(same_values_segment, Bound.LOWER)
 
         self.assertEqual(len(empty_detector_result_upper), 0)
         self.assertEqual(len(empty_detector_result_lower), 0)

--- a/analytics/tests/test_detectors.py
+++ b/analytics/tests/test_detectors.py
@@ -211,7 +211,7 @@ class TestAnomalyDetector(unittest.TestCase):
         result = [{ 'from': 1523889000010, 'to': 1523889000010 }]
         self.assertEqual(result, detected_segments)
 
-    def test_get_bounds_for_segment(self):
+    def test_get_bound_for_segment(self):
         detector = anomaly_detector.AnomalyDetector('test_id')
         peak_segment = pd.Series([1,2,3,4,3,2,1])
         trough_segment = pd.Series([4,3,2,1,2,3,4])
@@ -223,39 +223,43 @@ class TestAnomalyDetector(unittest.TestCase):
             'max_value': 3.5,
             'min_value': 2.75
         }
-        peak_detector_result = detector.get_bounds_for_segment(peak_segment)
-        trough_detector_result = detector.get_bounds_for_segment(trough_segment)
+        peak_detector_result_upper = detector.get_bound_for_segment(peak_segment, Bound.UPPER)
+        peak_detector_result_lower = detector.get_bound_for_segment(peak_segment, Bound.LOWER)
+        trough_detector_result_upper = detector.get_bound_for_segment(trough_segment, Bound.UPPER)
+        trough_detector_result_lower = detector.get_bound_for_segment(trough_segment, Bound.LOWER)
 
         self.assertGreaterEqual(
-            max(peak_detector_result[0]),
+            max(peak_detector_result_upper),
             expected_peak_segment_results['max_value']
         )
         self.assertLessEqual(
-            max(peak_detector_result[1]),
+            max(peak_detector_result_lower),
             expected_peak_segment_results['min_value']
         )
         self.assertGreaterEqual(
-            max(trough_detector_result[0]),
+            max(trough_detector_result_upper),
             expected_trough_segment_results['max_value']
         )
         self.assertLessEqual(
-            max(trough_detector_result[1]),
+            max(trough_detector_result_lower),
             expected_trough_segment_results['min_value']
         )
 
-    def test_get_bounds_for_segment_corner_cases(self):
+    def test_get_bound_for_segment_corner_cases(self):
         detector = anomaly_detector.AnomalyDetector('test_id')
         empty_segment = pd.Series([])
         same_values_segment = pd.Series([2,2,2,2,2,2])
-        empty_detector_result = detector.get_bounds_for_segment(empty_segment)
-        same_values_detector_result = detector.get_bounds_for_segment(same_values_segment)
+        empty_detector_result_upper = detector.get_bound_for_segment(empty_segment, Bound.UPPER)
+        empty_detector_result_lower = detector.get_bound_for_segment(empty_segment, Bound.LOWER)
+        same_values_detector_result_upper = detector.get_bound_for_segment(same_values_segment, Bound.UPPER)
+        same_values_detector_result_lower = detector.get_bound_for_segment(same_values_segment, Bound.LOWER)
 
-        self.assertEqual(len(empty_detector_result[0]), 0)
-        self.assertEqual(len(empty_detector_result[1]), 0)
-        self.assertEqual(min(same_values_detector_result[0]), 0)
-        self.assertEqual(max(same_values_detector_result[0]), 0)
-        self.assertEqual(min(same_values_detector_result[1]), 0)
-        self.assertEqual(max(same_values_detector_result[1]), 0)
+        self.assertEqual(len(empty_detector_result_upper), 0)
+        self.assertEqual(len(empty_detector_result_lower), 0)
+        self.assertEqual(min(same_values_detector_result_upper), 0)
+        self.assertEqual(max(same_values_detector_result_upper), 0)
+        self.assertEqual(min(same_values_detector_result_lower), 0)
+        self.assertEqual(max(same_values_detector_result_lower), 0)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This PR refactors `get_bounds_for_segment` Anomaly detector's method.

## Changes:
 - use [`operator` lib](https://docs.python.org/3/library/operator.html) to remove duplicated code.
 - `get_bounds_for_segment` -> `get_segment_bound`: 
    - new required `bound: Bound` argument
    - returns `upper` or `lower` bound instead of both bounds depending on the passed `bound` 