### PR TITLE
npm run build-614

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -6,7 +6,8 @@
     "start": "node dist/server.js",
     "dev": "NODE_ENV=development node build/dev-server.js",
     "build-prod": "npm rebuild zeromq && webpack --config build/webpack.prod.conf.js",
-    "build": "npm run build-prod && webpack --config build/webpack.614.prod.conf.js",
+    "build-614": "webpack --config build/webpack.614.prod.conf.js",
+    "build": "npm run build-prod && npm run build-614",
     "test": "jest --config jest.config.js"
   },
   "repository": {


### PR DESCRIPTION
split if `npm run build` to `npm run build-prod && npm run build-614` -- it is useful when you want to debug node 6.14 build process separately. 