### PR TITLE
Fix analytic model tester tool

### DIFF
--- a/analytics/tools/analytic_model_tester.py
+++ b/analytics/tools/analytic_model_tester.py
@@ -15,6 +15,7 @@ from detectors import pattern_detector, threshold_detector, anomaly_detector
 PEAK_DATASETS = []
 # dataset with 3 peaks
 TEST_DATA = test_dataset.create_dataframe([0, 0, 3, 5, 7, 5, 3, 0, 0, 1, 0, 1, 4, 6, 8, 6, 4, 1, 0, 0, 0, 1, 0, 3, 5, 7, 5, 3, 0, 1, 1])
+# TODO: more convenient way to specify labeled segments
 POSITIVE_SEGMENTS = [{'from': 1523889000001, 'to': 1523889000007}, {'from': 1523889000022, 'to': 1523889000028}]
 NEGATIVE_SEGMENTS = [{'from': 1523889000011, 'to': 1523889000017}]
 
@@ -117,6 +118,5 @@ if __name__ == '__main__':
         print(main(model_type))
     else:
         print('Enter one of models name: {}'.format(correct_name))
-
 
 

--- a/analytics/tools/analytic_model_tester.py
+++ b/analytics/tools/analytic_model_tester.py
@@ -94,8 +94,8 @@ def main(model_type: str) -> None:
             segments = data.get_segments_for_detection(1, 0)
             segments = [Segment.from_json(segment) for segment in segments]
             detector = pattern_detector.PatternDetector('PEAK', 'test_id')
-            train_result = detector.train(dataset, segments, {})
-            cache = train_result['cache']
+            training_result = detector.train(dataset, segments, {})
+            cache = training_result['cache']
             detect_result = detector.detect(dataset, cache)
             detect_result = detect_result.to_json()
             peak_metric = Metric(data.get_all_correct_segments(), detect_result)

--- a/analytics/tools/analytic_model_tester.py
+++ b/analytics/tools/analytic_model_tester.py
@@ -94,8 +94,8 @@ def main(model_type: str) -> None:
             segments = data.get_segments_for_detection(1, 0)
             segments = [Segment.from_json(segment) for segment in segments]
             detector = pattern_detector.PatternDetector('PEAK', 'test_id')
-            cache = detector.train(dataset, segments, {})
-            cache = cache['cache']
+            train_result = detector.train(dataset, segments, {})
+            cache = train_result['cache']
             detect_result = detector.detect(dataset, cache)
             detect_result = detect_result.to_json()
             peak_metric = Metric(data.get_all_correct_segments(), detect_result)


### PR DESCRIPTION
This PR makes `analytic_model_tester.py` tool work with current pattern models.

### Motivation:
`analytic_model_tester.py` tool was added a year ago and has never been updated.
The analytics code has changed, so the tool doesn't work.

## Changes:
 - analytics testing begins with creating instance of `Detector` instead of `Model`
 - rename `Segment` class to `TesterSegment`
 -  `ModelData` class: required segments with `{ "from": int, "to": int }` type