### PR TITLE
Abstract class for db connector #906

### DIFF
--- a/server/src/models/analytic_unit_cache_model.ts
+++ b/server/src/models/analytic_unit_cache_model.ts
@@ -1,5 +1,6 @@
 import { AnalyticUnitId, AnalyticUnit } from './analytic_units';
-import { Collection, makeDBQ } from '../services/data_service';
+import { Collection } from '../services/data_service/collection';
+import { makeDBQ } from '../services/data_service';
 
 import * as _ from 'lodash';
 

--- a/server/src/models/analytic_units/db.ts
+++ b/server/src/models/analytic_units/db.ts
@@ -1,7 +1,8 @@
 import { createAnalyticUnitFromObject } from './utils';
 import { AnalyticUnit } from './analytic_unit_model';
 import { AnalyticUnitId, FindManyQuery } from './types';
-import { Collection, makeDBQ, SortingOrder } from '../../services/data_service';
+import { Collection } from '../../services/data_service/collection';
+import { makeDBQ, SortingOrder } from '../../services/data_service';
 
 import { Metric } from 'grafana-datasource-kit';
 

--- a/server/src/models/detection_model.ts
+++ b/server/src/models/detection_model.ts
@@ -1,5 +1,6 @@
 import { AnalyticUnitId } from './analytic_units';
-import { Collection, makeDBQ } from '../services/data_service';
+import { Collection } from '../services/data_service/collection';
+import { makeDBQ } from '../services/data_service';
 
 import * as _ from 'lodash';
 

--- a/server/src/models/segment_model.ts
+++ b/server/src/models/segment_model.ts
@@ -1,7 +1,8 @@
 import { AnalyticUnitId } from './analytic_units';
 import * as AnalyticUnit from '../models/analytic_units';
 import * as AnalyticUnitCache from '../models/analytic_unit_cache_model';
-import { Collection, makeDBQ } from '../services/data_service';
+import { Collection } from '../services/data_service/collection';
+import { makeDBQ } from '../services/data_service';
 
 import * as _ from 'lodash';
 

--- a/server/src/services/data_service/collection.ts
+++ b/server/src/services/data_service/collection.ts
@@ -1,0 +1,8 @@
+export enum Collection {
+  ANALYTIC_UNITS,
+  ANALYTIC_UNIT_CACHES,
+  SEGMENTS,
+  THRESHOLD,
+  DETECTION_SPANS,
+  DB_META
+};

--- a/server/src/services/data_service/db_connector/factory.ts
+++ b/server/src/services/data_service/db_connector/factory.ts
@@ -1,0 +1,37 @@
+import { DBType } from '../../data_layer';
+import { DbConnector } from './index';
+import { MongodbConnector } from './mongodb_connector';
+import { NedbConnector } from './nedb_connector';
+
+import * as config from '../../../config';
+
+
+export class DbConnectorFactory {
+  private static _connector: DbConnector;
+
+  public static async getDbConnector(): Promise<DbConnector> {
+    if (this._connector !== undefined) {
+      return this._connector;
+    }
+
+    let connector: DbConnector;
+    switch (config.HASTIC_DB_CONNECTION_TYPE) {
+      case DBType.nedb:
+        connector = new NedbConnector();
+        break;
+
+      case DBType.mongodb:
+        connector = new MongodbConnector();
+        break;
+
+      default:
+        throw new Error(
+          `"${config.HASTIC_DB_CONNECTION_TYPE}" HASTIC_DB_CONNECTION_TYPE is not supported. Possible values: "nedb", "mongodb"`
+        );
+    }
+
+    await connector.init();
+    this._connector = connector;
+    return this._connector;
+  }
+}

--- a/server/src/services/data_service/db_connector/factory.ts
+++ b/server/src/services/data_service/db_connector/factory.ts
@@ -10,12 +10,12 @@ export class DbConnectorFactory {
   private static _connector: DbConnector;
 
   public static async getDbConnector(): Promise<DbConnector> {
-    if (this._connector !== undefined) {
+    if(this._connector !== undefined) {
       return this._connector;
     }
 
     let connector: DbConnector;
-    switch (config.HASTIC_DB_CONNECTION_TYPE) {
+    switch(config.HASTIC_DB_CONNECTION_TYPE) {
       case DBType.nedb:
         connector = new NedbConnector();
         break;

--- a/server/src/services/data_service/db_connector/factory.ts
+++ b/server/src/services/data_service/db_connector/factory.ts
@@ -9,6 +9,8 @@ import * as config from '../../../config';
 export class DbConnectorFactory {
   private static _connector: DbConnector;
 
+  private constructor() { }
+
   public static async getDbConnector(): Promise<DbConnector> {
     if(this._connector !== undefined) {
       return this._connector;
@@ -17,11 +19,11 @@ export class DbConnectorFactory {
     let connector: DbConnector;
     switch(config.HASTIC_DB_CONNECTION_TYPE) {
       case DBType.nedb:
-        connector = new NedbConnector();
+        connector = NedbConnector.instance;
         break;
 
       case DBType.mongodb:
-        connector = new MongodbConnector();
+        connector = MongodbConnector.instance;
         break;
 
       default:

--- a/server/src/services/data_service/db_connector/index.ts
+++ b/server/src/services/data_service/db_connector/index.ts
@@ -1,8 +1,8 @@
 import { Collection } from '../collection';
 import { dbCollection } from '../../data_layer';
 
-
 export interface DbConnector {
   db: Map<Collection, dbCollection>;
   init(): Promise<void>;
+  // TODO: static instance?
 }

--- a/server/src/services/data_service/db_connector/index.ts
+++ b/server/src/services/data_service/db_connector/index.ts
@@ -1,0 +1,14 @@
+import { Collection } from '../collection';
+import { dbCollection } from '../../data_layer';
+
+
+export abstract class DbConnector {
+  protected _db = new Map <Collection, dbCollection>();
+
+  constructor() { }
+  abstract async init();
+
+  get db(): Map<Collection, dbCollection> {
+    return this._db;
+  }
+}

--- a/server/src/services/data_service/db_connector/index.ts
+++ b/server/src/services/data_service/db_connector/index.ts
@@ -2,13 +2,7 @@ import { Collection } from '../collection';
 import { dbCollection } from '../../data_layer';
 
 
-export abstract class DbConnector {
-  protected _db = new Map<Collection, dbCollection>();
-
-  constructor() { }
-  abstract async init();
-
-  get db(): Map<Collection, dbCollection> {
-    return this._db;
-  }
+export interface DbConnector {
+  db: Map<Collection, dbCollection>;
+  init(): Promise<void>;
 }

--- a/server/src/services/data_service/db_connector/index.ts
+++ b/server/src/services/data_service/db_connector/index.ts
@@ -3,7 +3,7 @@ import { dbCollection } from '../../data_layer';
 
 
 export abstract class DbConnector {
-  protected _db = new Map <Collection, dbCollection>();
+  protected _db = new Map<Collection, dbCollection>();
 
   constructor() { }
   abstract async init();

--- a/server/src/services/data_service/db_connector/mongodb_connector.ts
+++ b/server/src/services/data_service/db_connector/mongodb_connector.ts
@@ -45,8 +45,9 @@ export class MongodbConnector extends DbConnector {
       MongodbConnector.COLLECTION_TO_NAME_MAPPING.forEach((name, collection) => {
         this._db.set(collection, hasticDb.collection(name));
       });
-    } catch (err) {
+    } catch(err) {
       console.log(`got error while connecting to MongoDB: ${err}`);
+      // TODO: throw a better error, e.g.: ServiceInitializationError
       throw err;
     }
   }

--- a/server/src/services/data_service/db_connector/mongodb_connector.ts
+++ b/server/src/services/data_service/db_connector/mongodb_connector.ts
@@ -22,6 +22,7 @@ export class MongodbConnector extends DbConnector {
   }
 
   async init() {
+    // TODO: move this log outside
     console.log('MongoDB is used as the storage');
     const dbConfig = config.HASTIC_DB_CONFIG;
     const uri = `mongodb://${dbConfig.user}:${dbConfig.password}@${dbConfig.url}`;

--- a/server/src/services/data_service/db_connector/mongodb_connector.ts
+++ b/server/src/services/data_service/db_connector/mongodb_connector.ts
@@ -35,6 +35,7 @@ export class MongodbConnector extends DbConnector {
       auth,
       autoReconnect: true,
       useUnifiedTopology: true,
+      // TODO: it should be configurable
       authMechanism: 'SCRAM-SHA-1',
       authSource: dbConfig.dbName
     });

--- a/server/src/services/data_service/db_connector/mongodb_connector.ts
+++ b/server/src/services/data_service/db_connector/mongodb_connector.ts
@@ -22,8 +22,6 @@ export class MongodbConnector extends DbConnector {
   }
 
   async init() {
-    // TODO: move this log outside
-    console.log('MongoDB is used as the storage');
     const dbConfig = config.HASTIC_DB_CONFIG;
     const uri = `mongodb://${dbConfig.user}:${dbConfig.password}@${dbConfig.url}`;
     const auth = {

--- a/server/src/services/data_service/db_connector/mongodb_connector.ts
+++ b/server/src/services/data_service/db_connector/mongodb_connector.ts
@@ -7,6 +7,8 @@ import * as mongodb from 'mongodb';
 
 
 export class MongodbConnector implements DbConnector {
+  private static _instance: MongodbConnector;
+
   private _db = new Map<Collection, dbCollection>();
 
   private static COLLECTION_TO_NAME_MAPPING = new Map<Collection, string>([
@@ -20,7 +22,7 @@ export class MongodbConnector implements DbConnector {
 
   private _client: mongodb.MongoClient;
 
-  constructor() { }
+  private constructor() { }
 
   async init(): Promise<void> {
     const dbConfig = config.HASTIC_DB_CONFIG;
@@ -56,5 +58,12 @@ export class MongodbConnector implements DbConnector {
 
   get db(): Map<Collection, dbCollection> {
     return this._db;
+  }
+
+  static get instance(): MongodbConnector {
+    if(this._instance === undefined) {
+      this._instance = new this();
+    }
+    return this._instance;
   }
 }

--- a/server/src/services/data_service/db_connector/mongodb_connector.ts
+++ b/server/src/services/data_service/db_connector/mongodb_connector.ts
@@ -1,0 +1,52 @@
+import { Collection } from '../collection';
+import { DbConnector } from './index';
+import * as config from '../../../config';
+
+import * as mongodb from 'mongodb';
+
+
+export class MongodbConnector extends DbConnector {
+  private static COLLECTION_TO_NAME_MAPPING = new Map<Collection, string>([
+    [Collection.ANALYTIC_UNITS, 'analytic_units'],
+    [Collection.ANALYTIC_UNIT_CACHES, 'analytic_unit_caches'],
+    [Collection.SEGMENTS, 'segments'],
+    [Collection.THRESHOLD, 'threshold'],
+    [Collection.DETECTION_SPANS, 'detection_spans'],
+    [Collection.DB_META, 'db_meta']
+  ]);
+
+  private _client: mongodb.MongoClient;
+
+  constructor() {
+    super();
+  }
+
+  async init() {
+    console.log('MongoDB is used as the storage');
+    const dbConfig = config.HASTIC_DB_CONFIG;
+    const uri = `mongodb://${dbConfig.user}:${dbConfig.password}@${dbConfig.url}`;
+    const auth = {
+      user: dbConfig.user,
+      password: dbConfig.password
+    };
+    this._client = new mongodb.MongoClient(uri, {
+      useNewUrlParser: true,
+      auth,
+      autoReconnect: true,
+      useUnifiedTopology: true,
+      authMechanism: 'SCRAM-SHA-1',
+      authSource: dbConfig.dbName
+    });
+
+    try {
+      const client: mongodb.MongoClient = await this._client.connect();
+      const hasticDb: mongodb.Db = client.db(dbConfig.dbName);
+      MongodbConnector.COLLECTION_TO_NAME_MAPPING.forEach((name, collection) => {
+        this._db.set(collection, hasticDb.collection(name));
+      });
+    } catch (err) {
+      console.log(`got error while connecting to MongoDB: ${err}`);
+      throw err;
+    }
+  }
+}

--- a/server/src/services/data_service/db_connector/nedb_connector.ts
+++ b/server/src/services/data_service/db_connector/nedb_connector.ts
@@ -43,8 +43,9 @@ export class NedbConnector extends DbConnector {
     // TODO: move this log outside
     console.log('NeDB is used as the storage');
     checkDataFolders();
-    
+
     const inMemoryOnly = config.HASTIC_DB_IN_MEMORY;
+    // TODO: it can throw an error, so we should catch it
     NedbConnector.COLLECTION_TO_CONFIG_MAPPING.forEach(
       (config: NedbCollectionConfig, collection: Collection) => {
         this._db.set(collection, new nedb({ ...config, autoload: true, inMemoryOnly }));

--- a/server/src/services/data_service/db_connector/nedb_connector.ts
+++ b/server/src/services/data_service/db_connector/nedb_connector.ts
@@ -6,6 +6,11 @@ import * as nedb from 'nedb';
 import * as fs from 'fs';
 
 
+type NedbCollectionConfig = {
+  filename: string,
+  timestampData?: boolean
+};
+
 function maybeCreateDir(path: string): void {
   if (fs.existsSync(path)) {
     return;
@@ -21,7 +26,7 @@ function checkDataFolders(): void {
 }
 
 export class NedbConnector extends DbConnector {
-  private static COLLECTION_TO_CONFIG_MAPPING = new Map<Collection, { filename: string, timestampData?: boolean }>([
+  private static COLLECTION_TO_CONFIG_MAPPING = new Map<Collection, NedbCollectionConfig>([
     [Collection.ANALYTIC_UNITS, { filename: config.ANALYTIC_UNITS_DATABASE_PATH, timestampData: true }],
     [Collection.ANALYTIC_UNIT_CACHES, { filename: config.ANALYTIC_UNIT_CACHES_DATABASE_PATH }],
     [Collection.SEGMENTS, { filename: config.SEGMENTS_DATABASE_PATH }],
@@ -35,12 +40,13 @@ export class NedbConnector extends DbConnector {
   }
 
   async init() {
-    checkDataFolders();
-    const inMemoryOnly = config.HASTIC_DB_IN_MEMORY;
+    // TODO: move this log outside
     console.log('NeDB is used as the storage');
-    // TODO: it's better if models request db which we create if it`s needed
+    checkDataFolders();
+    
+    const inMemoryOnly = config.HASTIC_DB_IN_MEMORY;
     NedbConnector.COLLECTION_TO_CONFIG_MAPPING.forEach(
-      (config: { filename: string, timestampData?: boolean }, collection: Collection) => {
+      (config: NedbCollectionConfig, collection: Collection) => {
         this._db.set(collection, new nedb({ ...config, autoload: true, inMemoryOnly }));
       }
     );

--- a/server/src/services/data_service/db_connector/nedb_connector.ts
+++ b/server/src/services/data_service/db_connector/nedb_connector.ts
@@ -27,6 +27,8 @@ function checkDataFolders(): void {
 }
 
 export class NedbConnector implements DbConnector {
+  private static _instance: NedbConnector;
+
   private _db = new Map<Collection, dbCollection>();
 
   private static COLLECTION_TO_CONFIG_MAPPING = new Map<Collection, NedbCollectionConfig>([
@@ -54,5 +56,12 @@ export class NedbConnector implements DbConnector {
 
   get db(): Map<Collection, dbCollection> {
     return this._db;
+  }
+
+  static get instance(): NedbConnector {
+    if (this._instance === undefined) {
+      this._instance = new this();
+    }
+    return this._instance;
   }
 }

--- a/server/src/services/data_service/db_connector/nedb_connector.ts
+++ b/server/src/services/data_service/db_connector/nedb_connector.ts
@@ -1,0 +1,48 @@
+import { Collection } from '../collection';
+import { DbConnector } from './index';
+import * as config from '../../../config';
+
+import * as nedb from 'nedb';
+import * as fs from 'fs';
+
+
+function maybeCreateDir(path: string): void {
+  if (fs.existsSync(path)) {
+    return;
+  }
+  console.log('data service: mkdir: ' + path);
+  fs.mkdirSync(path);
+}
+
+function checkDataFolders(): void {
+  [
+    config.DATA_PATH
+  ].forEach(maybeCreateDir);
+}
+
+export class NedbConnector extends DbConnector {
+  private static COLLECTION_TO_CONFIG_MAPPING = new Map<Collection, { filename: string, timestampData?: boolean }>([
+    [Collection.ANALYTIC_UNITS, { filename: config.ANALYTIC_UNITS_DATABASE_PATH, timestampData: true }],
+    [Collection.ANALYTIC_UNIT_CACHES, { filename: config.ANALYTIC_UNIT_CACHES_DATABASE_PATH }],
+    [Collection.SEGMENTS, { filename: config.SEGMENTS_DATABASE_PATH }],
+    [Collection.THRESHOLD, { filename: config.THRESHOLD_DATABASE_PATH }],
+    [Collection.DETECTION_SPANS, { filename: config.DETECTION_SPANS_DATABASE_PATH }],
+    [Collection.DB_META, { filename: config.DB_META_PATH }],
+  ]);
+
+  constructor() {
+    super();
+  }
+
+  async init() {
+    checkDataFolders();
+    const inMemoryOnly = config.HASTIC_DB_IN_MEMORY;
+    console.log('NeDB is used as the storage');
+    // TODO: it's better if models request db which we create if it`s needed
+    NedbConnector.COLLECTION_TO_CONFIG_MAPPING.forEach(
+      (config: { filename: string, timestampData?: boolean }, collection: Collection) => {
+        this._db.set(collection, new nedb({ ...config, autoload: true, inMemoryOnly }));
+      }
+    );
+  }
+}

--- a/server/src/services/data_service/db_connector/nedb_connector.ts
+++ b/server/src/services/data_service/db_connector/nedb_connector.ts
@@ -40,8 +40,6 @@ export class NedbConnector extends DbConnector {
   }
 
   async init() {
-    // TODO: move this log outside
-    console.log('NeDB is used as the storage');
     checkDataFolders();
 
     const inMemoryOnly = config.HASTIC_DB_IN_MEMORY;

--- a/server/src/services/data_service/db_connector/nedb_connector.ts
+++ b/server/src/services/data_service/db_connector/nedb_connector.ts
@@ -1,5 +1,6 @@
 import { Collection } from '../collection';
 import { DbConnector } from './index';
+import { dbCollection } from '../../data_layer';
 import * as config from '../../../config';
 
 import * as nedb from 'nedb';
@@ -25,7 +26,9 @@ function checkDataFolders(): void {
   ].forEach(maybeCreateDir);
 }
 
-export class NedbConnector extends DbConnector {
+export class NedbConnector implements DbConnector {
+  private _db = new Map<Collection, dbCollection>();
+
   private static COLLECTION_TO_CONFIG_MAPPING = new Map<Collection, NedbCollectionConfig>([
     [Collection.ANALYTIC_UNITS, { filename: config.ANALYTIC_UNITS_DATABASE_PATH, timestampData: true }],
     [Collection.ANALYTIC_UNIT_CACHES, { filename: config.ANALYTIC_UNIT_CACHES_DATABASE_PATH }],
@@ -35,11 +38,9 @@ export class NedbConnector extends DbConnector {
     [Collection.DB_META, { filename: config.DB_META_PATH }],
   ]);
 
-  constructor() {
-    super();
-  }
+  constructor() { }
 
-  async init() {
+  async init(): Promise<void> {
     checkDataFolders();
 
     const inMemoryOnly = config.HASTIC_DB_IN_MEMORY;
@@ -49,5 +50,9 @@ export class NedbConnector extends DbConnector {
         this._db.set(collection, new nedb({ ...config, autoload: true, inMemoryOnly }));
       }
     );
+  }
+
+  get db(): Map<Collection, dbCollection> {
+    return this._db;
   }
 }

--- a/server/src/services/data_service/index.ts
+++ b/server/src/services/data_service/index.ts
@@ -1,29 +1,10 @@
-import { getDbQueryWrapper, dbCollection, DBType } from '../data_layer';
-import * as config from '../../config';
+import { Collection } from './collection';
+import { getDbQueryWrapper, dbCollection } from '../data_layer';
+import { DbConnector } from './db_connector';
+import { DbConnectorFactory } from './db_connector/factory';
 
-import * as nedb from 'nedb';
-import * as fs from 'fs';
-import * as mongodb from 'mongodb';
 import * as deasync from 'deasync';
 
-
-export enum Collection { 
-  ANALYTIC_UNITS,
-  ANALYTIC_UNIT_CACHES,
-  SEGMENTS,
-  THRESHOLD,
-  DETECTION_SPANS,
-  DB_META
-};
-
-const COLLECTION_TO_NAME_MAPPING = new Map<Collection, string>([
-  [Collection.ANALYTIC_UNITS, 'analytic_units'],
-  [Collection.ANALYTIC_UNIT_CACHES, 'analytic_unit_caches'],
-  [Collection.SEGMENTS, 'segments'],
-  [Collection.THRESHOLD, 'threshold'],
-  [Collection.DETECTION_SPANS, 'detection_spans'],
-  [Collection.DB_META, 'db_meta']
-]);
 
 export enum SortingOrder { ASCENDING = 1, DESCENDING = -1 };
 
@@ -44,8 +25,7 @@ export type DBQ = {
 }
 
 const queryWrapper = getDbQueryWrapper();
-const db = new Map<Collection, dbCollection>();
-let mongoClient: mongodb.MongoClient;
+let db: Map<Collection, dbCollection>;
 
 function dbCollectionFromCollection(collection: Collection): dbCollection {
   let dbCollection = db.get(collection);
@@ -69,74 +49,10 @@ export function makeDBQ(collection: Collection): DBQ {
 }
 
 
-function maybeCreateDir(path: string): void {
-  if(fs.existsSync(path)) {
-    return;
-  }
-  console.log('data service: mkdir: ' + path);
-  fs.mkdirSync(path);
-}
-
-function checkDataFolders(): void {
-  [
-    config.DATA_PATH
-  ].forEach(maybeCreateDir);
-}
-
-async function connectToDb() {
-  if(config.HASTIC_DB_CONNECTION_TYPE === DBType.nedb) {
-    checkDataFolders();
-    const inMemoryOnly = config.HASTIC_DB_IN_MEMORY;
-    console.log('NeDB is used as the storage');
-    // TODO: it's better if models request db which we create if it`s needed
-    db.set(Collection.ANALYTIC_UNITS, new nedb({ filename: config.ANALYTIC_UNITS_DATABASE_PATH, autoload: true, timestampData: true, inMemoryOnly}));
-    db.set(Collection.ANALYTIC_UNIT_CACHES, new nedb({ filename: config.ANALYTIC_UNIT_CACHES_DATABASE_PATH, autoload: true, inMemoryOnly}));
-    db.set(Collection.SEGMENTS, new nedb({ filename: config.SEGMENTS_DATABASE_PATH, autoload: true, inMemoryOnly}));
-    db.set(Collection.THRESHOLD, new nedb({ filename: config.THRESHOLD_DATABASE_PATH, autoload: true, inMemoryOnly}));
-    db.set(Collection.DETECTION_SPANS, new nedb({ filename: config.DETECTION_SPANS_DATABASE_PATH, autoload: true, inMemoryOnly}));
-    db.set(Collection.DB_META, new nedb({ filename: config.DB_META_PATH, autoload: true, inMemoryOnly}));
-  } else if(config.HASTIC_DB_CONNECTION_TYPE === DBType.mongodb) {
-    console.log('MongoDB is used as the storage');
-    const dbConfig = config.HASTIC_DB_CONFIG;
-    const uri = `mongodb://${dbConfig.user}:${dbConfig.password}@${dbConfig.url}`;
-    const auth = {
-      user: dbConfig.user,
-      password: dbConfig.password
-    };
-    mongoClient = new mongodb.MongoClient(uri, {
-      useNewUrlParser: true,
-      auth,
-      autoReconnect: true,
-      useUnifiedTopology: true,
-      authMechanism: 'SCRAM-SHA-1',
-      authSource: dbConfig.dbName
-    });
-    try {
-      const client: mongodb.MongoClient = await mongoClient.connect();
-      const hasticDb: mongodb.Db = client.db(dbConfig.dbName);
-      COLLECTION_TO_NAME_MAPPING.forEach((name, collection) => {
-        db.set(collection, hasticDb.collection(name));
-      });
-    } catch(err) {
-      console.log(`got error while connect to MongoDB ${err}`);
-      throw err;
-    }
-  } else {
-    throw new Error(
-      `"${config.HASTIC_DB_CONNECTION_TYPE}" HASTIC_DB_CONNECTION_TYPE is not supported. Possible values: "nedb", "mongodb"`
-    );
-  }
-}
-
-export async function closeDb() {
-  if(mongoClient !== undefined && mongoClient.isConnected) {
-    await mongoClient.close();
-  }
-}
-
 let done = false;
-connectToDb().then(() => {
+DbConnectorFactory.getDbConnector().then((connector: DbConnector) => {
   done = true;
+  db = connector.db;
 }).catch((err) => {
   console.log(`data service got error while connect to data base ${err}`);
   //TODO: choose best practice for error handling

--- a/server/src/services/data_service/migrations.ts
+++ b/server/src/services/data_service/migrations.ts
@@ -7,7 +7,8 @@
   Note: do not import code from other modules here because it can be changed
 */
 
-import { Collection, makeDBQ } from './index';
+import { Collection } from './collection';
+import { makeDBQ } from './index';
 
 import * as _ from 'lodash';
 


### PR DESCRIPTION
Closes #906 

This PR is the 1st step to removing `deasync`.
Changes:
- create `DbConnector` interface
- move DB connection code from `data_service` to `DbConnector`s 
- instances of `DbConnector`s are produced by `DbConnectorFactory`
- fix imports