### PR TITLE
Remove deasync lib #829

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -37,7 +37,6 @@
     "babel-polyfill": "^6.26.0",
     "babel-preset-env": "^1.7.0",
     "babel-preset-es2015": "^6.24.1",
-    "deasync": "^0.1.15",
     "es6-promise": "^4.2.4",
     "event-stream": "3.3.4",
     "file-loader": "^1.1.11",

--- a/server/src/models/analytic_unit_cache_model.ts
+++ b/server/src/models/analytic_unit_cache_model.ts
@@ -1,11 +1,11 @@
 import { AnalyticUnitId, AnalyticUnit } from './analytic_units';
 import { Collection } from '../services/data_service/collection';
-import { makeDBQ } from '../services/data_service';
+import { DataService } from '../services/data_service';
 
 import * as _ from 'lodash';
 
 
-const db = makeDBQ(Collection.ANALYTIC_UNIT_CACHES);
+const db = DataService.getInstance().makeDBQ(Collection.ANALYTIC_UNIT_CACHES);
 // TODO: count milliseconds in index from dataset
 const MILLISECONDS_IN_INDEX = 60000;
 

--- a/server/src/models/analytic_units/db.ts
+++ b/server/src/models/analytic_units/db.ts
@@ -2,14 +2,14 @@ import { createAnalyticUnitFromObject } from './utils';
 import { AnalyticUnit } from './analytic_unit_model';
 import { AnalyticUnitId, FindManyQuery } from './types';
 import { Collection } from '../../services/data_service/collection';
-import { makeDBQ, SortingOrder } from '../../services/data_service';
+import { DataService, SortingOrder } from '../../services/data_service';
 
 import { Metric } from 'grafana-datasource-kit';
 
 import * as _ from 'lodash';
 
 
-const db = makeDBQ(Collection.ANALYTIC_UNITS);
+const db = DataService.getInstance().makeDBQ(Collection.ANALYTIC_UNITS);
 
 export async function findById(id: AnalyticUnitId): Promise<AnalyticUnit | null> {
   let obj = await db.findOne(id);

--- a/server/src/models/detection_model.ts
+++ b/server/src/models/detection_model.ts
@@ -1,10 +1,11 @@
 import { AnalyticUnitId } from './analytic_units';
 import { Collection } from '../services/data_service/collection';
-import { makeDBQ } from '../services/data_service';
+import { DataService } from '../services/data_service';
 
 import * as _ from 'lodash';
 
-let db = makeDBQ(Collection.DETECTION_SPANS);
+
+const db = DataService.getInstance().makeDBQ(Collection.DETECTION_SPANS);
 
 export enum DetectionStatus {
   READY = 'READY',

--- a/server/src/models/segment_model.ts
+++ b/server/src/models/segment_model.ts
@@ -2,12 +2,12 @@ import { AnalyticUnitId } from './analytic_units';
 import * as AnalyticUnit from '../models/analytic_units';
 import * as AnalyticUnitCache from '../models/analytic_unit_cache_model';
 import { Collection } from '../services/data_service/collection';
-import { makeDBQ } from '../services/data_service';
+import { DataService } from '../services/data_service';
 
 import * as _ from 'lodash';
 
-let db = makeDBQ(Collection.SEGMENTS);
 
+const db = DataService.getInstance().makeDBQ(Collection.SEGMENTS);
 
 export type SegmentId = string;
 
@@ -117,7 +117,7 @@ export async function findMany(id: AnalyticUnitId, query: FindManyQuery): Promis
 
 export async function findByAnalyticUnitIds(analyticUnitIds: AnalyticUnitId[]): Promise<any[]> {
   const segments = await db.findMany({ analyticUnitId: { $in: analyticUnitIds } });
-  
+
   if(segments === null) {
     return [];
   }

--- a/server/src/services/data_service/db_connector/mongodb_connector.ts
+++ b/server/src/services/data_service/db_connector/mongodb_connector.ts
@@ -8,9 +8,6 @@ import * as mongodb from 'mongodb';
 
 export class MongodbConnector implements DbConnector {
   private static _instance: MongodbConnector;
-
-  private _db = new Map<Collection, dbCollection>();
-
   private static COLLECTION_TO_NAME_MAPPING = new Map<Collection, string>([
     [Collection.ANALYTIC_UNITS, 'analytic_units'],
     [Collection.ANALYTIC_UNIT_CACHES, 'analytic_unit_caches'],
@@ -20,9 +17,14 @@ export class MongodbConnector implements DbConnector {
     [Collection.DB_META, 'db_meta']
   ]);
 
+  private _db = new Map<Collection, dbCollection>();
   private _client: mongodb.MongoClient;
 
-  private constructor() { }
+  private constructor() {
+    if(MongodbConnector._instance !== undefined) {
+      throw new Error(`Can't create 2nd instance of singleton MongodbConnector class`);
+    }
+  }
 
   async init(): Promise<void> {
     const dbConfig = config.HASTIC_DB_CONFIG;

--- a/server/src/services/data_service/db_connector/nedb_connector.ts
+++ b/server/src/services/data_service/db_connector/nedb_connector.ts
@@ -28,9 +28,6 @@ function checkDataFolders(): void {
 
 export class NedbConnector implements DbConnector {
   private static _instance: NedbConnector;
-
-  private _db = new Map<Collection, dbCollection>();
-
   private static COLLECTION_TO_CONFIG_MAPPING = new Map<Collection, NedbCollectionConfig>([
     [Collection.ANALYTIC_UNITS, { filename: config.ANALYTIC_UNITS_DATABASE_PATH, timestampData: true }],
     [Collection.ANALYTIC_UNIT_CACHES, { filename: config.ANALYTIC_UNIT_CACHES_DATABASE_PATH }],
@@ -40,7 +37,13 @@ export class NedbConnector implements DbConnector {
     [Collection.DB_META, { filename: config.DB_META_PATH }],
   ]);
 
-  constructor() { }
+  private _db = new Map<Collection, dbCollection>();
+
+  private constructor() {
+    if(NedbConnector._instance !== undefined) {
+      throw new Error(`Can't create 2nd instance of singleton MongodbConnector class`);
+    }
+  }
 
   async init(): Promise<void> {
     checkDataFolders();

--- a/server/src/services/data_service/index.ts
+++ b/server/src/services/data_service/index.ts
@@ -3,8 +3,6 @@ import { getDbQueryWrapper, dbCollection } from '../data_layer';
 import { DbConnector } from './db_connector';
 import { DbConnectorFactory } from './db_connector/factory';
 
-import * as deasync from 'deasync';
-
 
 export enum SortingOrder { ASCENDING = 1, DESCENDING = -1 };
 
@@ -24,38 +22,79 @@ export type DBQ = {
   removeMany: (query: string[] | object) => Promise<number>
 }
 
-const queryWrapper = getDbQueryWrapper();
-let db: Map<Collection, dbCollection>;
+export class DataService {
+  private static _instance: DataService;
 
-function dbCollectionFromCollection(collection: Collection): dbCollection {
-  let dbCollection = db.get(collection);
-  if(dbCollection === undefined) {
-    throw new Error('Can`t find collection ' + collection);
+  private _queryWrapper = getDbQueryWrapper();
+
+  private constructor() {
+    if(DataService._instance !== undefined) {
+      throw new Error(`Can't create 2nd instance of singleton class`);
+    }
   }
-  return dbCollection;
-}
 
-export function makeDBQ(collection: Collection): DBQ {
-  return {
-    findOne: queryWrapper.dbFindOne.bind(null, dbCollectionFromCollection(collection)),
-    findMany: queryWrapper.dbFindMany.bind(null, dbCollectionFromCollection(collection)),
-    insertOne: queryWrapper.dbInsertOne.bind(null, dbCollectionFromCollection(collection)),
-    insertMany: queryWrapper.dbInsertMany.bind(null, dbCollectionFromCollection(collection)),
-    updateOne: queryWrapper.dbUpdateOne.bind(null, dbCollectionFromCollection(collection)),
-    updateMany: queryWrapper.dbUpdateMany.bind(null, dbCollectionFromCollection(collection)),
-    removeOne: queryWrapper.dbRemoveOne.bind(null, dbCollectionFromCollection(collection)),
-    removeMany: queryWrapper.dbRemoveMany.bind(null, dbCollectionFromCollection(collection))
+  private async getConnector(): Promise<DbConnector> {
+    try {
+      const connector = await DbConnectorFactory.getDbConnector();
+      return connector;
+    } catch(err) {
+      console.log(`data service got an error while connecting to database: ${err}`);
+      throw err;
+    }
+  }
+
+  public static getInstance(): DataService {
+    if(DataService._instance === undefined) {
+      DataService._instance = new DataService();
+    }
+    return DataService._instance;
+  }
+
+  public makeDBQ(collection: Collection): DBQ {
+    return {
+      findOne: async (query: object | string) => {
+        const dbCollection = await this.getDbCollectionFromCollection(collection);
+        return this._queryWrapper.dbFindOne(dbCollection, query);
+      },
+      findMany: async (query: object | string[], sortQuery: object) => {
+        const dbCollection = await this.getDbCollectionFromCollection(collection);
+        return this._queryWrapper.dbFindMany(dbCollection, query, sortQuery);
+      },
+      insertOne: async (doc: object) => {
+        const dbCollection = await this.getDbCollectionFromCollection(collection);
+        return this._queryWrapper.dbInsertOne(dbCollection, doc);
+      },
+      insertMany: async (docs: object[]) => {
+        const dbCollection = await this.getDbCollectionFromCollection(collection);
+        return this._queryWrapper.dbInsertMany(dbCollection, docs);
+      },
+      updateOne: async(query: object | string, updateQuery: object) => {
+        const dbCollection = await this.getDbCollectionFromCollection(collection);
+        return this._queryWrapper.dbUpdateOne(dbCollection, query, updateQuery);
+      },
+      updateMany: async (query: object | string[], updateQuery: object) => {
+        const dbCollection = await this.getDbCollectionFromCollection(collection);
+        return this._queryWrapper.dbUpdateMany(dbCollection, query, updateQuery);
+      },
+      removeOne: async (query: string | object) => {
+        const dbCollection = await this.getDbCollectionFromCollection(collection);
+        return this._queryWrapper.dbRemoveOne(dbCollection, query);
+      },
+      removeMany: async (query: object | string[]) => {
+        const dbCollection = await this.getDbCollectionFromCollection(collection);
+        return this._queryWrapper.dbRemoveMany(dbCollection, query);
+      }
+    };
+  }
+
+  private async getDbCollectionFromCollection(collection: Collection): Promise<dbCollection> {
+    const connector = await this.getConnector();
+    const db = connector.db;
+
+    let dbCollection = db.get(collection);
+    if (dbCollection === undefined) {
+      throw new Error('Can`t find collection ' + collection);
+    }
+    return dbCollection;
   }
 }
-
-
-let done = false;
-DbConnectorFactory.getDbConnector().then((connector: DbConnector) => {
-  done = true;
-  db = connector.db;
-}).catch((err) => {
-  console.log(`data service got error while connect to data base ${err}`);
-  //TODO: choose best practice for error handling
-  throw err;
-});
-deasync.loopWhile(() => !done);

--- a/server/src/services/data_service/index.ts
+++ b/server/src/services/data_service/index.ts
@@ -24,22 +24,11 @@ export type DBQ = {
 
 export class DataService {
   private static _instance: DataService;
-
   private _queryWrapper = getDbQueryWrapper();
 
   private constructor() {
     if(DataService._instance !== undefined) {
       throw new Error(`Can't create 2nd instance of singleton class`);
-    }
-  }
-
-  private async getConnector(): Promise<DbConnector> {
-    try {
-      const connector = await DbConnectorFactory.getDbConnector();
-      return connector;
-    } catch(err) {
-      console.log(`data service got an error while connecting to database: ${err}`);
-      throw err;
     }
   }
 
@@ -53,46 +42,56 @@ export class DataService {
   public makeDBQ(collection: Collection): DBQ {
     return {
       findOne: async (query: object | string) => {
-        const dbCollection = await this.getDbCollectionFromCollection(collection);
+        const dbCollection = await this._getDbCollectionFromCollection(collection);
         return this._queryWrapper.dbFindOne(dbCollection, query);
       },
       findMany: async (query: object | string[], sortQuery: object) => {
-        const dbCollection = await this.getDbCollectionFromCollection(collection);
+        const dbCollection = await this._getDbCollectionFromCollection(collection);
         return this._queryWrapper.dbFindMany(dbCollection, query, sortQuery);
       },
       insertOne: async (doc: object) => {
-        const dbCollection = await this.getDbCollectionFromCollection(collection);
+        const dbCollection = await this._getDbCollectionFromCollection(collection);
         return this._queryWrapper.dbInsertOne(dbCollection, doc);
       },
       insertMany: async (docs: object[]) => {
-        const dbCollection = await this.getDbCollectionFromCollection(collection);
+        const dbCollection = await this._getDbCollectionFromCollection(collection);
         return this._queryWrapper.dbInsertMany(dbCollection, docs);
       },
       updateOne: async(query: object | string, updateQuery: object) => {
-        const dbCollection = await this.getDbCollectionFromCollection(collection);
+        const dbCollection = await this._getDbCollectionFromCollection(collection);
         return this._queryWrapper.dbUpdateOne(dbCollection, query, updateQuery);
       },
       updateMany: async (query: object | string[], updateQuery: object) => {
-        const dbCollection = await this.getDbCollectionFromCollection(collection);
+        const dbCollection = await this._getDbCollectionFromCollection(collection);
         return this._queryWrapper.dbUpdateMany(dbCollection, query, updateQuery);
       },
       removeOne: async (query: string | object) => {
-        const dbCollection = await this.getDbCollectionFromCollection(collection);
+        const dbCollection = await this._getDbCollectionFromCollection(collection);
         return this._queryWrapper.dbRemoveOne(dbCollection, query);
       },
       removeMany: async (query: object | string[]) => {
-        const dbCollection = await this.getDbCollectionFromCollection(collection);
+        const dbCollection = await this._getDbCollectionFromCollection(collection);
         return this._queryWrapper.dbRemoveMany(dbCollection, query);
       }
     };
   }
 
-  private async getDbCollectionFromCollection(collection: Collection): Promise<dbCollection> {
-    const connector = await this.getConnector();
+  private async _getConnector(): Promise<DbConnector> {
+    try {
+      const connector = await DbConnectorFactory.getDbConnector();
+      return connector;
+    } catch (err) {
+      console.log(`data service got an error while connecting to database: ${err}`);
+      throw err;
+    }
+  }
+
+  private async _getDbCollectionFromCollection(collection: Collection): Promise<dbCollection> {
+    const connector = await this._getConnector();
     const db = connector.db;
 
     let dbCollection = db.get(collection);
-    if (dbCollection === undefined) {
+    if(dbCollection === undefined) {
       throw new Error('Can`t find collection ' + collection);
     }
     return dbCollection;

--- a/server/src/services/data_service/migrations.ts
+++ b/server/src/services/data_service/migrations.ts
@@ -8,15 +8,15 @@
 */
 
 import { Collection } from './collection';
-import { makeDBQ } from './index';
+import { DataService } from './index';
 
 import * as _ from 'lodash';
 
 
-const metaDB = makeDBQ(Collection.DB_META);
-const analyticUnitsDB = makeDBQ(Collection.ANALYTIC_UNITS);
-const analyticUnitCachesDB = makeDBQ(Collection.ANALYTIC_UNIT_CACHES);
-const thresholdsDB = makeDBQ(Collection.THRESHOLD);
+const metaDB = DataService.getInstance().makeDBQ(Collection.DB_META);
+const analyticUnitsDB = DataService.getInstance().makeDBQ(Collection.ANALYTIC_UNITS);
+const analyticUnitCachesDB = DataService.getInstance().makeDBQ(Collection.ANALYTIC_UNIT_CACHES);
+const thresholdsDB = DataService.getInstance().makeDBQ(Collection.THRESHOLD);
 
 const DB_META_ID = '000000000000000000000001'; //24 symbols for mongodb
 
@@ -124,7 +124,7 @@ async function integrateThresholdsIntoAnalyticUnits() {
 async function addDetectorTypes() {
   const analyticUnits = await analyticUnitsDB.findMany({ detectorType: { $exists: false } });
 
-  const promises = analyticUnits.map(analyticUnit => 
+  const promises = analyticUnits.map(analyticUnit =>
     analyticUnitsDB.updateOne(analyticUnit._id, { detectorType: getDetectorByType(analyticUnit.type) })
   );
 


### PR DESCRIPTION
Closes #829 

Changes:
- create `DataService` singleton class out of  `data_service/index.ts` content
- wrap `DBQ` methods into `async` method which connects to DB before using (if it haven't connected yet)
- remove `deasync` dep
- fix `DataService` usage: `makeDBQ()` -> `DataService.getInstance().makeDBQ()`

Non-related changes:
- fix `DbConnector`s: throw an error in `constructor` if instance is already created