### PR TITLE
Configurable logging level hastic/analytics#19

### DIFF
--- a/config.example.json
+++ b/config.example.json
@@ -3,5 +3,6 @@
   "HASTIC_API_KEY": "eyJrIjoiVjZqMHY0dHk4UEE3eEN4MzgzRnd2aURlMWlIdXdHNW4iLCJuIjoiaGFzdGljIiwiaWQiOjF9",
   "HASTIC_WEBHOOK_URL": "http://localhost:8080",
   "GRAFANA_URL": "http://localhost:3000",
-  "LEARNING_TIMEOUT": 120
+  "LEARNING_TIMEOUT": 120,
+  "HS_AL_LOGGING_LEVEL": "DEBUG"
 }

--- a/config.example.json
+++ b/config.example.json
@@ -4,5 +4,5 @@
   "HASTIC_WEBHOOK_URL": "http://localhost:8080",
   "GRAFANA_URL": "http://localhost:3000",
   "LEARNING_TIMEOUT": 120,
-  "HS_AL_LOGGING_LEVEL": "DEBUG"
+  "HS_AN_LOGGING_LEVEL": "DEBUG"
 }

--- a/docker-compose-mongo.yml
+++ b/docker-compose-mongo.yml
@@ -34,7 +34,7 @@ services:
     environment:
       # TODO: use any port for server connection
       HASTIC_SERVER_URL: "ws://server:8002"
-      HS_AL_LOGGING_LEVEL: ${HS_AL_LOGGING_LEVEL}
+      HS_AN_LOGGING_LEVEL: ${HS_AN_LOGGING_LEVEL}
     networks:
       - hastic-network
     restart: always

--- a/docker-compose-mongo.yml
+++ b/docker-compose-mongo.yml
@@ -34,6 +34,7 @@ services:
     environment:
       # TODO: use any port for server connection
       HASTIC_SERVER_URL: "ws://server:8002"
+      HS_AL_LOGGING_LEVEL: ${HS_AL_LOGGING_LEVEL}
     networks:
       - hastic-network
     restart: always

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,7 +32,7 @@ services:
     environment:
       # TODO: use any port for server connection
       HASTIC_SERVER_URL: "ws://server:8002"
-      HS_AL_LOGGING_LEVEL: ${HS_AL_LOGGING_LEVEL}
+      HS_AN_LOGGING_LEVEL: ${HS_AN_LOGGING_LEVEL}
     networks:
       - hastic-network
     restart: always

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,6 +32,7 @@ services:
     environment:
       # TODO: use any port for server connection
       HASTIC_SERVER_URL: "ws://server:8002"
+      HS_AL_LOGGING_LEVEL: ${HS_AL_LOGGING_LEVEL}
     networks:
       - hastic-network
     restart: always


### PR DESCRIPTION
2nd part of https://github.com/hastic/analytics/pull/20 PR

## Changes:
- add `HS_AL_LOGGING_LEVEL` config field to `docker-compose.yml`, `docker-compose-mongo.yml` and `config.example.json`

## PLEASE NOTE
> `analytics` sub-repo commit hash should be updated after merging analytics PR