### PR TITLE
Fix Docker build

### DIFF
--- a/server/build/webpack.prod.conf.js
+++ b/server/build/webpack.prod.conf.js
@@ -7,31 +7,10 @@ const fs = require('fs');
 var base = require('./webpack.base.conf');
 
 const TARGET_NODE_VERSION = process.versions.node;
-const PLATFORM = `${process.platform}-${process.arch}-node-${TARGET_NODE_VERSION.split('.')[0]}`;
-const DEASYNC_NODE_MODULES_PATH = path.resolve('node_modules', 'deasync', 'bin', PLATFORM);
-const DEASYNC_DIST_PATH = path.resolve('dist', 'bin', PLATFORM);
-
-console.log(`Target node version: ${TARGET_NODE_VERSION}`);
-console.log(`Platform: ${PLATFORM}`);
-
-if(!fs.existsSync(DEASYNC_NODE_MODULES_PATH)) {
-  throw new Error(`deasync doesn't support this platform: ${PLATFORM}`);
-}
 
 base.mode = 'production';
 base.output.filename = "server.js";
 base.optimization.minimize = true;
-
-base.externals = base.externals ? base.externals : [];
-base.externals.push(
-  function (context, request, callback) {
-    if(request.indexOf('bindings') === 0) {
-      callback(null, `() => require('./deasync.node')`)
-    } else {
-      callback();
-    }
-  }
-);
 
 const prodRules = [
   {
@@ -57,18 +36,6 @@ const prodRules = [
   }
 ];
 
-let contextPathMapping = {};
-contextPathMapping[path.resolve(DEASYNC_DIST_PATH, 'deasync')] = './deasync.node';
-
-const prodPlugins = [
-  new webpack.ContextReplacementPlugin(
-    /deasync/,
-    DEASYNC_NODE_MODULES_PATH,
-    contextPathMapping
-  )
-];
-
 base.module.rules = [...base.module.rules, ...prodRules];
-base.plugins = [...base.plugins, ...prodPlugins];
 
 module.exports = base;

--- a/server/package.json
+++ b/server/package.json
@@ -53,7 +53,7 @@
     "nodemon": "^1.17.5",
     "ts-jest": "^23.1.1",
     "ts-loader": "^4.4.1",
-    "typescript": "^2.8.3",
+    "typescript": "^3.9.5",
     "url": "^0.11.0",
     "webpack": "^4.12.0",
     "webpack-cli": "^3.0.8",

--- a/server/spec/setup_tests.ts
+++ b/server/spec/setup_tests.ts
@@ -13,7 +13,5 @@ jest.mock('../src/config.ts', () => ({
   AlertTypes: jest.requireActual('../src/config').AlertTypes,
 }));
 
-jest.mock('deasync', () => ({ loopWhile: jest.fn() }));
-
 clearSegmentsDB();
 createTestDB();


### PR DESCRIPTION
I tried to build Hastic in Docker and got these errors:

```
Error: deasync doesn't support this platform: linux-x64-node-8
```
Reason: we've removed `deasync` lib but it's still used in webpack

```
ERROR in /var/www/server/node_modules/@types/mongodb/index.d.ts
[tsl] ERROR in /var/www/server/node_modules/@types/mongodb/index.d.ts(39,1)
      TS1084: Invalid 'reference' directive syntax.
```
Reason: [TypeScript version is too old](https://github.com/DefinitelyTyped/DefinitelyTyped/issues/10097)

## Changes
- remove `deasync` usage from webpack config
- upgrade `typescript`: `2.8.3` -> `3.9.5`

## Other changes
- remove `deasync` from tests #916