### PR TITLE
.env.example with variables documentation

### DIFF
--- a/server/.env.example
+++ b/server/.env.example
@@ -1,0 +1,12 @@
+# Hastic server port
+HASTIC_PORT=8000
+# Grafana Api token (https://grafana.com/docs/grafana/latest/http_api/auth/#create-api-token)
+HASTIC_API_KEY=eyJrIjoiVjZqMHY0dHk4UEE3eEN4MzgzRnd2aURlMWlIdXdHNW4iLCJuIjoiaGFzdGljIiwiaWQiOjF9
+# Url to send a notification when anomalies are detected
+HASTIC_WEBHOOK_URL=http://localhost:8080
+# Grafana server url
+GRAFANA_URL=http://localhost:3000
+# Time we wait for a response from hastic/analytics before sending the error
+LEARNING_TIMEOUT=120
+# Log level: 'DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL'
+HS_AN_LOGGING_LEVEL=DEBUG

--- a/server/.env.example
+++ b/server/.env.example
@@ -12,16 +12,16 @@ HASTIC_PORT=8000
 # (optional) use it if you want to get webhooks on detections (e.g. http://localhost:8080)
 HASTIC_WEBHOOK_URL=http://localhost:8080
 
-# (optional) Address for sending notifications when patterns are detected (e.g. webhook or alertmanager)
+# (optional) type of alerts (detections) receiver (e.g. webhook or alertmanager)
 HASTIC_ALERT_TYPE=
 
-# (optional) service address where to send notifications if ALERT_TYPE is alertmanager (e.g http://localhost:3000)
+# (optional) URL to send alerts if ALERT_TYPE is alertmanager (e.g http://localhost:9093)
 HASTIC_ALERTMANAGER_URL=
 
-# (optional) service address where to send notifications if ALERT_TYPE is webhook (e.g http://localhost:3000)
+# (optional) URL to send alerts if ALERT_TYPE is webhook (e.g. http://localhost:8080)
 HASTIC_WEBHOOK_URL=
 
-# (optional) Name of the hastic instance from which we get alerts
+# (optional) Hastic instance name which is used in alerts
 HASTIC_INSTANCE_NAME=
 
 # (optional) whether to send a chart in the notification
@@ -33,5 +33,5 @@ HASTIC_DB_CONNECTION_STRING=
 # (optional) database type. Can have the following values: nedb, mongodb
 HASTIC_DB_CONNECTION_TYPE=
 
-# timezone offset in hours from utc
+# (optional) timezone offset in hours from utc (e.g -3:30)
 HASTIC_TIMEZONE_OFFSET=

--- a/server/.env.example
+++ b/server/.env.example
@@ -1,12 +1,40 @@
-# Hastic server port
+# (optional) port you want to run server on, default: 8000
 HASTIC_PORT=8000
-# Grafana Api token (https://grafana.com/docs/grafana/latest/http_api/auth/#create-api-token)
-HASTIC_API_KEY=eyJrIjoiVjZqMHY0dHk4UEE3eEN4MzgzRnd2aURlMWlIdXdHNW4iLCJuIjoiaGFzdGljIiwiaWQiOjF9
-# Url to send a notification when anomalies are detected
+
+# (required) API-key of your Grafana instance
+# (e.g. eyJrIjoiVjZqMHY0dHk4UEE3eEN4MzgzRnd2aURlMWlIdXdHNW4iLCJuIjoiaGFzdGljIiwiaWQiOjF9),
+# see Get-HASTIC_API_KEY(https://grafana.com/docs/grafana/latest/http_api/auth/#create-api-token)
+HASTIC_API_KEY=
+
+# (optional) use it if you want to get webhooks with new detections (e.g.http://localhost:8080)
 HASTIC_WEBHOOK_URL=http://localhost:8080
-# Grafana server url
+
+# (optional) can be either application/x-www-form-urlencoded or application/json
+HASTIC_WEBHOOK_TYPE=
+
+# (required) Grafana URL which can be queried from hastic-server host (e.g. http://localhost:3000),
 GRAFANA_URL=http://localhost:3000
-# Time we wait for a response from hastic/analytics before sending the error
-LEARNING_TIMEOUT=120
-# Log level: 'DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL'
-HS_AN_LOGGING_LEVEL=DEBUG
+
+# (optional) Address for sending notifications when patterns are detected (e.g. webhook or alertmanager)
+HASTIC_ALERT_TYPE=
+
+# (optional) service address where to send notifications if ALERT_TYPE is alertmanager (e.g http://localhost:3000)
+HASTIC_ALERTMANAGER_URL=
+
+# (optional) service address where to send notifications if ALERT_TYPE is webhook (e.g http://localhost:3000)
+HASTIC_WEBHOOK_URL=
+
+# (optional) Name of the hastic instance from which we get alerts
+HASTIC_INSTANCE_NAME=
+
+# (optional) whether to send a chart in the notification
+HASTIC_ALERT_IMAGE=
+
+# (optional) connection-string for MongoDB (not used with nedb), (e.g. hastic:password@mongodb.example.com:27017/hastic)
+HASTIC_DB_CONNECTION_STRING=
+
+# (optional) database type. Can have the following values: nedb, mongodb
+HASTIC_DB_CONNECTION_TYPE=
+
+# timezone offset in hours from utc
+HASTIC_TIMEZONE_OFFSET=

--- a/server/.env.example
+++ b/server/.env.example
@@ -1,19 +1,16 @@
-# (optional) port you want to run server on, default: 8000
-HASTIC_PORT=8000
+# (required) Grafana URL which can be queried from hastic-server host (e.g. http://localhost:3000),
+GRAFANA_URL=http://localhost:3000
 
 # (required) API-key of your Grafana instance
 # (e.g. eyJrIjoiVjZqMHY0dHk4UEE3eEN4MzgzRnd2aURlMWlIdXdHNW4iLCJuIjoiaGFzdGljIiwiaWQiOjF9),
-# see Get-HASTIC_API_KEY(https://grafana.com/docs/grafana/latest/http_api/auth/#create-api-token)
+# see https://grafana.com/docs/grafana/latest/http_api/auth/#create-api-token
 HASTIC_API_KEY=
 
-# (optional) use it if you want to get webhooks with new detections (e.g.http://localhost:8080)
+# (optional) port you want to run server on, default: 8000
+HASTIC_PORT=8000
+
+# (optional) use it if you want to get webhooks on detections (e.g. http://localhost:8080)
 HASTIC_WEBHOOK_URL=http://localhost:8080
-
-# (optional) can be either application/x-www-form-urlencoded or application/json
-HASTIC_WEBHOOK_TYPE=
-
-# (required) Grafana URL which can be queried from hastic-server host (e.g. http://localhost:3000),
-GRAFANA_URL=http://localhost:3000
 
 # (optional) Address for sending notifications when patterns are detected (e.g. webhook or alertmanager)
 HASTIC_ALERT_TYPE=

--- a/server/.env.example
+++ b/server/.env.example
@@ -6,6 +6,9 @@ GRAFANA_URL=http://localhost:3000
 # see https://grafana.com/docs/grafana/latest/http_api/auth/#create-api-token
 HASTIC_API_KEY=
 
+# (optional) websockets URL to connect to hastic-server from analytics
+HASTIC_SERVER_URL=ws://localhost:8002
+
 # (optional) port you want to run server on, default: 8000
 HASTIC_PORT=8000
 
@@ -17,9 +20,6 @@ HASTIC_ALERT_TYPE=
 
 # (optional) URL to send alerts if ALERT_TYPE is alertmanager (e.g http://localhost:9093)
 HASTIC_ALERTMANAGER_URL=
-
-# (optional) URL to send alerts if ALERT_TYPE is webhook (e.g. http://localhost:8080)
-HASTIC_WEBHOOK_URL=
 
 # (optional) Hastic instance name which is used in alerts
 HASTIC_INSTANCE_NAME=

--- a/server/package.json
+++ b/server/package.json
@@ -18,7 +18,9 @@
     "url": "https://github.com/hastic/hastic-server/issues"
   },
   "homepage": "https://github.com/hastic/hastic-server#readme",
-  "dependencies": {},
+  "dependencies": {
+    "dotenv": "^8.2.0"
+  },
   "devDependencies": {
     "@types/deasync": "^0.1.0",
     "@types/jest": "^23.3.14",

--- a/server/package.json
+++ b/server/package.json
@@ -18,9 +18,7 @@
     "url": "https://github.com/hastic/hastic-server/issues"
   },
   "homepage": "https://github.com/hastic/hastic-server#readme",
-  "dependencies": {
-    "dotenv": "^8.2.0"
-  },
+  "dependencies": {},
   "devDependencies": {
     "@corpglory/tsdb-kit": "^1.1.1",
     "@types/deasync": "^0.1.0",
@@ -40,6 +38,7 @@
     "babel-polyfill": "^6.26.0",
     "babel-preset-env": "^1.7.0",
     "babel-preset-es2015": "^6.24.1",
+    "dotenv": "^8.2.0",
     "es6-promise": "^4.2.4",
     "event-stream": "3.3.4",
     "file-loader": "^1.1.11",

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -168,13 +168,13 @@ function getHasticServerUrl() {
 
   try {
     const url = new URL(urlString);
-    if (url.protocol !== 'ws:') {
-      throw new Error('Invalid protocol');
+    if(url.protocol !== 'ws:') {
+      throw new Error(`Invalid protocol ${url.protocol}`);
     }
 
     return url;
-  } catch {
-    console.log('Invalid HASTIC_SERVER_URL, value must be url, got:', urlString);
+  } catch(e) {
+    console.log(`Invalid HASTIC_SERVER_URL, value must be url, got: ${urlString}`);
     exit(EXIT_CODE_BAD_VALUE_FIELD);
   }
 }

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -8,8 +8,7 @@ import * as path from 'path';
 import * as fs from 'fs';
 import * as os from 'os';
 import { exit } from 'process'; // it's very bad to use it in config, but life is full of pain
-
-require('dotenv').config();
+import * as dotenv from 'dotenv';
 
 const EXIT_CODE_MISSING_FIELD = 3;
 const EXIT_CODE_BAD_VALUE_FIELD = 4;
@@ -19,6 +18,8 @@ const EXIT_CODE_BAD_VALUE_FIELD = 4;
 declare const GIT_BRANCH: string;
 declare const GIT_COMMITHASH: string;
 declare const GIT_VERSION: string;
+
+dotenv.config();
 
 let configFile = path.join(__dirname, '../../config.json');
 let configExists = fs.existsSync(configFile);

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -92,9 +92,7 @@ export const HASTIC_INSTANCE_NAME = getConfigFieldAndPrintOrExit('HASTIC_INSTANC
  */
 function getConfigFieldAndPrintOrExit(field: string, defaultVal?: any, allowedVals?: any[]) {
   let val;
-  if (field === 'HASTIC_API_KEY') {
-    console.log('HASTIC_API_KEY<-------', process.env[field]);
-  }
+
   if(process.env[field] !== undefined) {
     val = process.env[field];
   } else if(configExists) {

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -9,6 +9,8 @@ import * as fs from 'fs';
 import * as os from 'os';
 import { exit } from 'process'; // it's very bad to use it in config, but life is full of pain
 
+require('dotenv').config();
+
 const EXIT_CODE_MISSING_FIELD = 3;
 const EXIT_CODE_BAD_VALUE_FIELD = 4;
 
@@ -90,7 +92,9 @@ export const HASTIC_INSTANCE_NAME = getConfigFieldAndPrintOrExit('HASTIC_INSTANC
  */
 function getConfigFieldAndPrintOrExit(field: string, defaultVal?: any, allowedVals?: any[]) {
   let val;
-
+  if (field === 'HASTIC_API_KEY') {
+    console.log('HASTIC_API_KEY<-------', process.env[field]);
+  }
   if(process.env[field] !== undefined) {
     val = process.env[field];
   } else if(configExists) {

--- a/server/src/services/analytics_service.ts
+++ b/server/src/services/analytics_service.ts
@@ -10,6 +10,7 @@ import * as childProcess from 'child_process'
 import * as fs from 'fs';
 import * as path from 'path';
 import * as _ from 'lodash';
+import { HASTIC_SERVER_URL } from '../config';
 
 
 export class AnalyticsService {
@@ -76,10 +77,10 @@ export class AnalyticsService {
   public get lastAlive(): Date { return this._lastAlive; }
 
   private async _init() {
-    this._socket_server = new WebSocket.Server({ port: 8002 });
+    this._socket_server = new WebSocket.Server({ host: HASTIC_SERVER_URL });
 
     // TODO: move this to config OR use existing http server
-    console.log("Creating websocket server ... %s", 'ws://localhost:8002');
+    console.log("Creating websocket server ... %s", HASTIC_SERVER_URL);
 
     this._socket_server.on("connection", this._onNewConnection.bind(this));
     // TODO: handle connection drop

--- a/server/src/services/analytics_service.ts
+++ b/server/src/services/analytics_service.ts
@@ -77,7 +77,8 @@ export class AnalyticsService {
   public get lastAlive(): Date { return this._lastAlive; }
 
   private async _init() {
-    this._socket_server = new WebSocket.Server({ host: HASTIC_SERVER_URL });
+    const hasticServerPort = +HASTIC_SERVER_URL.split(':').pop() || 80;
+    this._socket_server = new WebSocket.Server({ port: hasticServerPort });
 
     // TODO: move this to config OR use existing http server
     console.log("Creating websocket server ... %s", HASTIC_SERVER_URL);

--- a/server/src/services/analytics_service.ts
+++ b/server/src/services/analytics_service.ts
@@ -77,11 +77,10 @@ export class AnalyticsService {
   public get lastAlive(): Date { return this._lastAlive; }
 
   private async _init() {
-    const hasticServerPort = +HASTIC_SERVER_URL.split(':').pop() || 80;
-    this._socket_server = new WebSocket.Server({ port: hasticServerPort });
+    this._socket_server = new WebSocket.Server({ host: HASTIC_SERVER_URL.hostname, port: +HASTIC_SERVER_URL.port });
 
     // TODO: move this to config OR use existing http server
-    console.log("Creating websocket server ... %s", HASTIC_SERVER_URL);
+    console.log("Creating websocket server ... %s", HASTIC_SERVER_URL.origin);
 
     this._socket_server.on("connection", this._onNewConnection.bind(this));
     // TODO: handle connection drop
@@ -112,7 +111,7 @@ export class AnalyticsService {
       cwd: config.ANALYTICS_PATH,
       env: {
         ...process.env,
-        HASTIC_SERVER_URL: config.HASTIC_SERVER_URL
+        HASTIC_SERVER_URL: config.HASTIC_SERVER_URL.origin
       }
     };
 


### PR DESCRIPTION
**Changes**  
1) Added .env.example files with descriptions of each variable inside.  
2) Added 'dotenv' library to load variables from .env file
  
Now you can create .env files based on them for separate hastic/server and hastic/analytics use  