### PR TITLE
Single RPM version for all node versions since 6.14

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,26 +2,12 @@
 
 all: rpm deb
 
-rpm_node8:
+rpm:
 	docker run --rm -it -v `pwd`/server:/root/rpmbuild/server \
 			-v `pwd`/analytics:/root/rpmbuild/analytics \
 			-v `pwd`/.git:/root/rpmbuild/.git \
 			-v `pwd`/build/rpmbuild:/root/rpmbuild/rpm \
-			-v `pwd`/dist/RPMS_8:/root/rpmbuild/RPMS \
-			-e "NODE_VERSION=v8.0.0" \
-			-e "RPM_NODE_VERSION=8" \
+			-v `pwd`/dist/RPMS:/root/rpmbuild/RPMS \
+			-e "NODE_VERSION=6.14.0" \
 			-e "HASTIC_RELEASE_VERSION=`cat server/package.json| jq -r .version | sed 's/-/_/g'`" \
 			hastic/rpmbuilder rpmbuild -bb rpm/hastic-server.spec
-
-rpm_node6:
-	docker run --rm -v `pwd`/server:/root/rpmbuild/server \
-			-v `pwd`/analytics:/root/rpmbuild/analytics \
-			-v `pwd`/.git:/root/rpmbuild/.git \
-			-v `pwd`/build/rpmbuild:/root/rpmbuild/rpm \
-			-v `pwd`/dist/RPMS_6:/root/rpmbuild/RPMS \
-			-e "NODE_VERSION=v6.14.0" \
-			-e "RPM_NODE_VERSION=6" \
-			-e "HASTIC_RELEASE_VERSION=`cat server/package.json| jq -r .version | sed 's/-/_/g'`" \
-			hastic/rpmbuilder rpmbuild -bb rpm/hastic-server.spec
-
-rpm: rpm_node8 rpm_node6

--- a/build/rpmbuild/hastic-server.spec
+++ b/build/rpmbuild/hastic-server.spec
@@ -1,5 +1,5 @@
 %define name hastic-server
-%define version %{getenv:HASTIC_RELEASE_VERSION}_node%{getenv:RPM_NODE_VERSION}
+%define version %{getenv:HASTIC_RELEASE_VERSION}
 %define release 0
 %define buildroot /root/rpmbuild/BUILDROOT
 %define builddir /root/rpmbuild/BUILD
@@ -61,12 +61,8 @@ popd
 
 %install
 mkdir -p %{buildroot}/usr/lib/hastic-server/server/dist
-mkdir -p %{buildroot}/usr/lib/hastic-server/.git/refs/heads
 mkdir -p %{buildroot}/usr/lib/hastic-server/analytics/dist/server
 cp -r server/dist %{buildroot}/usr/lib/hastic-server/server/
-cp -r server/package.json %{buildroot}/usr/lib/hastic-server/server/
-cp -r .git/HEAD %{buildroot}/usr/lib/hastic-server/.git
-cp -r .git/refs/heads/ %{buildroot}/usr/lib/hastic-server/.git/refs/
 cp -r analytics/dist/server %{buildroot}/usr/lib/hastic-server/analytics/dist/
 
 %post


### PR DESCRIPTION
This PR makes `rpmbuilder` use node 6.14.0 to build `server.js` for any node
We can do it because we don't use C++ libraries anymore. So we don't need to make separate builds for different node.js versions.
