### PR TITLE
Fix anomaly detector webhooks

### DIFF
--- a/server/src/controllers/analytics_controller.ts
+++ b/server/src/controllers/analytics_controller.ts
@@ -73,7 +73,7 @@ export async function onDetect(detectionResult: DetectionResult): Promise<Segmen
     AnalyticUnit.setDetectionTime(id, payload.lastDetectionTime),
   ]);
 
-  if(insertionResult.removedIds.length === insertionResult.addedIds.length) {
+  if(!insertionResult.anyNewSegments) {
     if(insertionResult.removedIds.length > 0) {
       console.log('All found segments are merged with the existing ones');
     }

--- a/server/src/controllers/analytics_controller.ts
+++ b/server/src/controllers/analytics_controller.ts
@@ -74,7 +74,7 @@ export async function onDetect(detectionResult: DetectionResult): Promise<Segmen
   ]);
 
   if(insertionResult.removedIds.length === insertionResult.addedIds.length) {
-    if (insertionResult.removedIds.length > 0) {
+    if(insertionResult.removedIds.length > 0) {
       console.log('All found segments are merged with the existing ones');
     }
     return [];

--- a/server/src/controllers/analytics_controller.ts
+++ b/server/src/controllers/analytics_controller.ts
@@ -72,8 +72,11 @@ export async function onDetect(detectionResult: DetectionResult): Promise<Segmen
     AnalyticUnitCache.setData(id, payload.cache),
     AnalyticUnit.setDetectionTime(id, payload.lastDetectionTime),
   ]);
-  // removedIds.length > 0 means that there was at least 1 merge
-  if(insertionResult.removedIds.length > 0) {
+
+  if(insertionResult.removedIds.length === insertionResult.addedIds.length) {
+    if (insertionResult.removedIds.length > 0) {
+      console.log('All found segments are merged with the existing ones');
+    }
     return [];
   }
 
@@ -86,6 +89,7 @@ export async function onDetect(detectionResult: DetectionResult): Promise<Segmen
  */
 async function onPushDetect(detectionResult: DetectionResult): Promise<void> {
   const analyticUnit = await AnalyticUnit.findById(detectionResult.analyticUnitId);
+  console.log('Webhook detection result:');
   const segments = await onDetect(detectionResult);
   if(!_.isEmpty(segments) && analyticUnit.alert) {
     try {


### PR DESCRIPTION
Now we don't send an alert if at least 1 segment was merged while inserting. This PR fixes the behavior.

Changes:
- while inserting segments into the DB, check whether there are any new (non-merged) segments inserted, then send an alert