### PR TITLE
Slack: support images in alerts #801

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -18,11 +18,10 @@
     "url": "https://github.com/hastic/hastic-server/issues"
   },
   "homepage": "https://github.com/hastic/hastic-server#readme",
-  "dependencies": {
-    "@slack/web-api": "^6.0.0"
-  },
+  "dependencies": {},
   "devDependencies": {
     "@corpglory/tsdb-kit": "^1.1.1",
+    "@slack/web-api": "^6.0.0",
     "@types/jest": "^23.3.14",
     "@types/koa": "^2.0.46",
     "@types/koa-bodyparser": "^4.2.0",

--- a/server/package.json
+++ b/server/package.json
@@ -18,7 +18,9 @@
     "url": "https://github.com/hastic/hastic-server/issues"
   },
   "homepage": "https://github.com/hastic/hastic-server#readme",
-  "dependencies": {},
+  "dependencies": {
+    "@slack/web-api": "^6.0.0"
+  },
   "devDependencies": {
     "@corpglory/tsdb-kit": "^1.1.1",
     "@types/jest": "^23.3.14",

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -64,7 +64,8 @@ export const ORG_ID = getConfigFieldAndPrintOrExit('ORG_ID', 1);
 
 export enum AlertTypes {
   WEBHOOK = 'webhook',
-  ALERTMANAGER = 'alertmanager'
+  ALERTMANAGER = 'alertmanager',
+  SLACK = 'slack'
 };
 export const HASTIC_ALERT_TYPE = getConfigFieldAndPrintOrExit('HASTIC_ALERT_TYPE', AlertTypes.WEBHOOK, _.values(AlertTypes));
 export const HASTIC_ALERT_IMAGE = getConfigFieldAndPrintOrExit('HASTIC_ALERT_IMAGE', false);
@@ -73,6 +74,9 @@ export const HASTIC_WEBHOOK_URL = getConfigFieldAndPrintOrExit('HASTIC_WEBHOOK_U
 export const HASTIC_TIMEZONE_OFFSET = getTimeZoneOffset();
 
 export const HASTIC_ALERTMANAGER_URL = getConfigFieldAndPrintOrExit('HASTIC_ALERTMANAGER_URL', null);
+
+export const HASTIC_SLACK_API_TOKEN = getConfigFieldAndPrintOrExit('HASTIC_SLACK_API_TOKEN', null);
+export const HASTIC_SLACK_NOTIFICATION_CHANNEL = getConfigFieldAndPrintOrExit('HASTIC_SLACK_NOTIFICATION_CHANNEL', null);
 
 export const ANALYTICS_PING_INTERVAL = 500; // ms
 export const PACKAGE_VERSION = getPackageVersion();

--- a/server/src/controllers/analytics_controller.ts
+++ b/server/src/controllers/analytics_controller.ts
@@ -73,8 +73,8 @@ export async function onDetect(detectionResult: DetectionResult): Promise<Segmen
     AnalyticUnit.setDetectionTime(id, payload.lastDetectionTime),
   ]);
 
-  if(insertionResult.removedIds.length === insertionResult.addedIds.length) {
-    if (insertionResult.removedIds.length > 0) {
+  if(!insertionResult.anyNewSegments) {
+    if(insertionResult.removedIds.length > 0) {
       console.log('All found segments are merged with the existing ones');
     }
     return [];

--- a/server/src/controllers/analytics_controller.ts
+++ b/server/src/controllers/analytics_controller.ts
@@ -72,8 +72,11 @@ export async function onDetect(detectionResult: DetectionResult): Promise<Segmen
     AnalyticUnitCache.setData(id, payload.cache),
     AnalyticUnit.setDetectionTime(id, payload.lastDetectionTime),
   ]);
-  // removedIds.length > 0 means that there was at least 1 merge
-  if(insertionResult.removedIds.length > 0) {
+
+  if(insertionResult.removedIds.length === insertionResult.addedIds.length) {
+    if (insertionResult.removedIds.length > 0) {
+      console.log('All found segments are merged with the existing ones');
+    }
     return [];
   }
 
@@ -86,6 +89,7 @@ export async function onDetect(detectionResult: DetectionResult): Promise<Segmen
  */
 async function onPushDetect(detectionResult: DetectionResult): Promise<void> {
   const analyticUnit = await AnalyticUnit.findById(detectionResult.analyticUnitId);
+  console.log('Webhook detection result:');
   const segments = await onDetect(detectionResult);
   if(!_.isEmpty(segments) && analyticUnit.alert) {
     try {

--- a/server/src/services/alert_service.ts
+++ b/server/src/services/alert_service.ts
@@ -20,15 +20,16 @@ export class Alert {
   };
 
   protected async send(segment) {
-    const notification = await this.makeNotification(segment);
+    const notification = await this.generateNotification(segment);
     try {
       await Notifier.sendNotification(notification);
+      console.log('notification is successfully sent');
     } catch(error) {
       console.error(`can't send notification ${error}`);
     };
   }
 
-  protected async makeNotification(segment: Segment): Promise<Notification> {
+  protected async generateNotification(segment: Segment): Promise<Notification> {
     const meta = this.makeMeta(segment);
     const text = this.makeMessage(meta);
     let result: Notification = { meta, text };
@@ -44,7 +45,7 @@ export class Alert {
     return result;
   }
 
-  protected async loadImage() {
+  protected async loadImage(): Promise<Buffer> {
     const headers = { Authorization: `Bearer ${HASTIC_API_KEY}` };
     const dashdoardId = this.analyticUnit.panelId.split('/')[0];
     const panelId = this.analyticUnit.panelId.split('/')[1];
@@ -63,7 +64,7 @@ export class Alert {
       headers,
       responseType: 'arraybuffer'
     });
-    return new Buffer(response.data, 'binary').toString('base64');
+    return new Buffer(response.data, 'binary');
   }
 
   protected makeMeta(segment: Segment): AnalyticMeta {

--- a/server/src/services/alert_service.ts
+++ b/server/src/services/alert_service.ts
@@ -22,6 +22,7 @@ export class Alert {
   protected async send(segment) {
     const notification = await this.generateNotification(segment);
     try {
+      console.log('sending a notification...');
       await Notifier.sendNotification(notification);
       console.log('notification is successfully sent');
     } catch(error) {
@@ -35,6 +36,7 @@ export class Alert {
     let result: Notification = { meta, text };
     if(HASTIC_ALERT_IMAGE) {
       try {
+        console.log('Trying to load image for notification');
         const image = await this.loadImage();
         result.image = image;
       } catch(err) {
@@ -215,6 +217,7 @@ export class AlertService {
       to: now
     }
 
+    console.log('sending a notification...');
     Notifier.sendNotification({ text, meta: infoAlert }).catch((err) => {
       console.error(`can't send message ${err.message}`);
     });

--- a/server/src/services/alert_service.ts
+++ b/server/src/services/alert_service.ts
@@ -3,6 +3,7 @@ import * as AnalyticUnit from '../models/analytic_units';
 import { Segment } from '../models/segment_model';
 import { availableReporter } from '../utils/reporter';
 import { toTimeZone } from '../utils/time';
+import { getGrafanaUrl } from '../utils/grafana';
 import { ORG_ID, HASTIC_API_KEY, HASTIC_ALERT_IMAGE } from '../config';
 
 import axios from 'axios';
@@ -51,10 +52,11 @@ export class Alert {
     const headers = { Authorization: `Bearer ${HASTIC_API_KEY}` };
     const dashdoardId = this.analyticUnit.panelId.split('/')[0];
     const panelId = this.analyticUnit.panelId.split('/')[1];
-    const dashboardApiURL = `${this.analyticUnit.grafanaUrl}/api/dashboards/uid/${dashdoardId}`;
+    const grafanaUrl = getGrafanaUrl(this.analyticUnit.grafanaUrl);
+    const dashboardApiURL = `${grafanaUrl}/api/dashboards/uid/${dashdoardId}`;
     const dashboardInfo: any = await axios.get(dashboardApiURL, { headers });
     const dashboardName = _.last(dashboardInfo.data.meta.url.split('/'));
-    const renderUrl = `${this.analyticUnit.grafanaUrl}/render/d-solo/${dashdoardId}/${dashboardName}`;
+    const renderUrl = `${grafanaUrl}/render/d-solo/${dashdoardId}/${dashboardName}`;
     const params = {
       panelId,
       ordId: ORG_ID,
@@ -72,14 +74,15 @@ export class Alert {
   protected makeMeta(segment: Segment): AnalyticMeta {
     const dashdoardId = this.analyticUnit.panelId.split('/')[0];
     const panelId = this.analyticUnit.panelId.split('/')[1];
-    const grafanaUrl = `${this.analyticUnit.grafanaUrl}/d/${dashdoardId}?panelId=${panelId}&edit=true&fullscreen=true?orgId=${ORG_ID}`;
+    const grafanaUrl = getGrafanaUrl(this.analyticUnit.grafanaUrl);
+    const notificationUrl = `${grafanaUrl}/d/${dashdoardId}?panelId=${panelId}&edit=true&fullscreen=true?orgId=${ORG_ID}`;
 
     let alert: AnalyticMeta = {
       type: WebhookType.DETECT,
       analyticUnitType: this.analyticUnit.type,
       analyticUnitName: this.analyticUnit.name,
       analyticUnitId: this.analyticUnit.id,
-      grafanaUrl,
+      grafanaUrl: notificationUrl,
       from: segment.from,
       to: segment.to,
       message: segment.message

--- a/server/src/services/notification_service.ts
+++ b/server/src/services/notification_service.ts
@@ -183,6 +183,8 @@ class SlackNotifier implements Notifier {
       }
     }
 
+    console.log('Sending a notification...')
+
     await client.chat.postMessage({
       text: notification.text,
       attachments: [{ image_url: imageUrl }],

--- a/server/src/services/notification_service.ts
+++ b/server/src/services/notification_service.ts
@@ -182,8 +182,6 @@ class SlackNotifier implements Notifier {
       }
     }
 
-    console.log('Sending a notification...')
-
     await client.chat.postMessage({
       text: notification.text,
       attachments: [{ image_url: imageUrl }],

--- a/server/src/services/notification_service.ts
+++ b/server/src/services/notification_service.ts
@@ -1,6 +1,7 @@
 import * as AnalyticUnit from '../models/analytic_units';
 import * as config from '../config';
 
+import { WebClient } from '@slack/web-api';
 import axios from 'axios';
 import * as _ from 'lodash';
 
@@ -33,7 +34,7 @@ export type AnalyticMeta = {
 export declare type Notification = {
   text: string,
   meta: MetaInfo | AnalyticMeta,
-  image?: any
+  image?: Buffer
 }
 
 // TODO: split notifiers into 3 files
@@ -51,6 +52,10 @@ export function getNotifier(): Notifier {
     return new AlertManagerNotifier();
   }
 
+  if(config.HASTIC_ALERT_TYPE === config.AlertTypes.SLACK) {
+    return new SlackNotifier();
+  }
+
   throw new Error(`${config.HASTIC_ALERT_TYPE} alert type not supported`);
 }
 
@@ -60,9 +65,12 @@ class WebhookNotifier implements Notifier {
       console.log(`HASTIC_WEBHOOK_URL is not set, skip sending notification: ${notification.text}`);
       return;
     }
-  
+
     notification.text += `\nInstance: ${config.HASTIC_INSTANCE_NAME}`;
-    const data = JSON.stringify(notification);
+    const data = JSON.stringify({
+      ...notification,
+      image: notification.image === undefined ? notification.image : notification.image.toString('base64')
+    });
 
     const options = {
       method: 'POST',
@@ -121,7 +129,7 @@ class AlertManagerNotifier implements Notifier {
     }
 
     annotations.message += `\nInstance: ${config.HASTIC_INSTANCE_NAME}`;
-    
+
     let alertData: PostableAlert = {
       labels,
       annotations,
@@ -134,12 +142,52 @@ class AlertManagerNotifier implements Notifier {
       data: JSON.stringify([alertData]),
       headers: { 'Content-Type': 'application/json' }
     };
-  
+
     // first part: send "start" request
     await axios(options);
     // TODO: resolve FAILURE alert only after RECOVERY event
     // second part: send "end" request
     options.data = JSON.stringify([alertData]);
     await axios(options);
+  }
+}
+
+class SlackNotifier implements Notifier {
+  async sendNotification(notification: Notification) {
+    if(config.HASTIC_SLACK_API_TOKEN === null) {
+      console.log(`HASTIC_SLACK_API_TOKEN is not set, skip sending notification: ${notification.text}`);
+      return;
+    }
+
+    if(config.HASTIC_SLACK_NOTIFICATION_CHANNEL === null) {
+      console.log(`HASTIC_SLACK_NOTIFICATION_CHANNEL is not set, skip sending notification: ${notification.text}`);
+      return;
+    }
+
+    notification.text += `\nInstance: ${config.HASTIC_INSTANCE_NAME}`;
+
+    const client = new WebClient();
+
+    let imageUrl = '';
+    if(notification.image !== undefined) {
+      const uploadedFile = await client.files.upload({
+        channels: config.HASTIC_SLACK_NOTIFICATION_CHANNEL,
+        file: notification.image,
+        token: config.HASTIC_SLACK_API_TOKEN
+      });
+
+      if(uploadedFile.file) {
+        console.log(uploadedFile.file)
+        // @ts-ignore
+        imageUrl = uploadedFile.file.url_private;
+      }
+    }
+
+    await client.chat.postMessage({
+      text: notification.text,
+      attachments: [{ image_url: imageUrl }],
+      channel: config.HASTIC_SLACK_NOTIFICATION_CHANNEL,
+      token: config.HASTIC_SLACK_API_TOKEN
+    });
   }
 }

--- a/server/src/services/notification_service.ts
+++ b/server/src/services/notification_service.ts
@@ -177,7 +177,6 @@ class SlackNotifier implements Notifier {
       });
 
       if(uploadedFile.file) {
-        console.log(uploadedFile.file)
         // @ts-ignore
         imageUrl = uploadedFile.file.url_private;
       }


### PR DESCRIPTION
Slack doesn't support images uploading through webhooks, only with API. This PR adds new `slack` alert type which can send alerts to Slack with images

![image](https://user-images.githubusercontent.com/1989898/105025880-f9d76280-5a5e-11eb-8e7d-abb2dbb407e4.png)

Changes:
- new `@slack/web-api` dep
- new configuration options:
  - `HASTIC_SLACK_API_TOKEN`: https://slack.com/intl/en-ru/help/articles/115005265703-Create-a-bot-for-your-workspace
  - `HASTIC_SLACK_NOTIFICATION_CHANNEL`: name of channel to send alerts to
- new `slack` alert type
- return `Buffer` instead of base64-string from `loadImage` so that we can use it with `files.upload` Slack-API method
- new related wiki page: https://github.com/hastic/hastic-server/wiki/Slack

Other changes:
- rename `makeNotification` method to `generateNotification`